### PR TITLE
Adding basic .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: c
+sudo: required
+
+before_install:
+  - sudo apt-get -qq update
+  - sudo apt-get install -y gfortran openmpi-bin libopenmpi-dev
+
+install: true
+
+script:
+  - make clean
+  - make


### PR DESCRIPTION
This should help to address the concern raised yesterday about testing.

If you create a travis-ci account and link it to the main github it will pull on each commit to the repository and attempt to run this script, currently it only does

make clean
make

but it should be possible to integrate those test scripts you were discussing yesterday.