### PR TITLE
Correcting Cray compiler target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,8 +31,7 @@ FC = mpinagfor
 FFLAGS = -fpp
 else ifeq ($(CMP),cray)
 FC = ftn
-FFLAGS = -cpp -xHost -O3 -ipo -heaparrays -safe-cray-ptr -g -traceback
-PLATFORM=intel
+FFLAGS = -eF -g -O3 -N 1023
 endif
 
 


### PR DESCRIPTION
The "Cray" compiler was actually setup to use the Intel compiler
with Cray wrappers - this replaces it to use Cray compilers. 

To use Intel compilers on a Cray machine the invocation would be:

FC=ftn make CMP=intel

(I think, not tested as don't have access to a Cray/Intel machine)