### PR TITLE
Make the application of velocity to/from momentum explicitly lmn only

### DIFF
--- a/src/xcompact3d.f90
+++ b/src/xcompact3d.f90
@@ -68,8 +68,10 @@ program xcompact3d
         call boundary_conditions(rho1,ux1,uy1,uz1,phi1,ep1)
         call calculate_transeq_rhs(drho1,dux1,duy1,duz1,dphi1,rho1,ux1,uy1,uz1,ep1,phi1,divu3)
 
-        !! XXX N.B. from this point, X-pencil velocity arrays contain momentum.
-        call velocity_to_momentum(rho1,ux1,uy1,uz1)
+        if (ilmn) then
+           !! XXX N.B. from this point, X-pencil velocity arrays contain momentum (LMN only).
+           call velocity_to_momentum(rho1,ux1,uy1,uz1)
+        endif
 
         call int_time(rho1,ux1,uy1,uz1,phi1,drho1,dux1,duy1,duz1,dphi1)
         call pre_correc(ux1,uy1,uz1,ep1)
@@ -78,9 +80,12 @@ program xcompact3d
         call solve_poisson(pp3,px1,py1,pz1,rho1,ux1,uy1,uz1,ep1,drho1,divu3)
         call cor_vel(ux1,uy1,uz1,px1,py1,pz1)
 
-        call momentum_to_velocity(rho1,ux1,uy1,uz1)
-        !! XXX N.B. from this point, X-pencil velocity arrays contain velocity.
-
+        if (ilmn) then
+           call momentum_to_velocity(rho1,ux1,uy1,uz1)
+           !! XXX N.B. from this point, X-pencil velocity arrays contain velocity (LMN only).
+           !! Note - all other solvers work on velocity always
+        endif
+        
         call test_flow(rho1,ux1,uy1,uz1,phi1,ep1,drho1,divu3)
 
      enddo !! End sub timesteps


### PR DESCRIPTION
This does not change the program logic, only clarifies that it is
only the LMN solver that works with momentum (i.e. d rho u dt), all
others work with velocity.
The subroutines that convert to/from velocity and momentum exit
early if non-LMN, however the comments in the main program suggest
otherwise.