### PR TITLE
When restarting statistics you should read ifirst-1

### DIFF
--- a/src/statistics.f90
+++ b/src/statistics.f90
@@ -123,45 +123,48 @@ contains
 
     ! Local variables
     integer :: is
+    integer :: stattime
     character(len=30) :: filename
 
     if (nrank==0) then
       print *,'==========================================================='
       if (flag_read) then
-        print *,'Reading stat file', itime
+        stattime = itime - 1
+        print *,'Reading stat file', stattime
       else
-        print *,'Writing stat file', itime
+        stattime = itime
+        print *,'Writing stat file', stattime
       endif
     endif
 
-    write(filename,"('pmean.dat',I7.7)") itime
+    write(filename,"('pmean.dat',I7.7)") stattime
     call read_or_write_one_stat(flag_read, filename, pmean)
-    write(filename,"('umean.dat',I7.7)") itime
+    write(filename,"('umean.dat',I7.7)") stattime
     call read_or_write_one_stat(flag_read, filename, umean)
-    write(filename,"('vmean.dat',I7.7)") itime
+    write(filename,"('vmean.dat',I7.7)") stattime
     call read_or_write_one_stat(flag_read, filename, vmean)
-    write(filename,"('wmean.dat',I7.7)") itime
+    write(filename,"('wmean.dat',I7.7)") stattime
     call read_or_write_one_stat(flag_read, filename, wmean)
 
-    write(filename,"('uumean.dat',I7.7)") itime
+    write(filename,"('uumean.dat',I7.7)") stattime
     call read_or_write_one_stat(flag_read, filename, uumean)
-    write(filename,"('vvmean.dat',I7.7)") itime
+    write(filename,"('vvmean.dat',I7.7)") stattime
     call read_or_write_one_stat(flag_read, filename, vvmean)
-    write(filename,"('wwmean.dat',I7.7)") itime
+    write(filename,"('wwmean.dat',I7.7)") stattime
     call read_or_write_one_stat(flag_read, filename, wwmean)
 
-    write(filename,"('uvmean.dat',I7.7)") itime
+    write(filename,"('uvmean.dat',I7.7)") stattime
     call read_or_write_one_stat(flag_read, filename, uvmean)
-    write(filename,"('uwmean.dat',I7.7)") itime
+    write(filename,"('uwmean.dat',I7.7)") stattime
     call read_or_write_one_stat(flag_read, filename, uwmean)
-    write(filename,"('vwmean.dat',I7.7)") itime
+    write(filename,"('vwmean.dat',I7.7)") stattime
     call read_or_write_one_stat(flag_read, filename, vwmean)
 
     if (iscalar==1) then
        do is=1, numscalar
-          write(filename,"('phi',I2.2,'mean.dat',I7.7)") is, itime
+          write(filename,"('phi',I2.2,'mean.dat',I7.7)") is, stattime
           call read_or_write_one_stat(flag_read, filename, phimean(:,:,:,is))
-          write(filename,"('phiphi',I2.2,'mean.dat',I7.7)") is, itime
+          write(filename,"('phiphi',I2.2,'mean.dat',I7.7)") is, stattime
           call read_or_write_one_stat(flag_read, filename, phiphimean(:,:,:,is))
        enddo
     endif

--- a/src/statistics.f90
+++ b/src/statistics.f90
@@ -129,14 +129,18 @@ contains
     if (nrank==0) then
       print *,'==========================================================='
       if (flag_read) then
-        stattime = itime - 1
         print *,'Reading stat file', stattime
       else
-        stattime = itime
         print *,'Writing stat file', stattime
       endif
     endif
 
+    if (flag_read) then
+        stattime = itime - 1
+    else
+        stattime = itime
+    endif
+    
     write(filename,"('pmean.dat',I7.7)") stattime
     call read_or_write_one_stat(flag_read, filename, pmean)
     write(filename,"('umean.dat',I7.7)") stattime


### PR DESCRIPTION
This matches how the flow field restart is done, also as implemented
the restart statistics were not identical to an un-restarted run

====================================================
Comments from X3d/slack:

Paul 5:37 PM
Hi, I’m a bit confused about the stats restart. If I restart from itime=x then I read my initial condition from checkpoint itime=x-1, however for the stats it reads from stat file itime=x (which I don’t think should exist). This doesn’t seem right to me, but I don’t want to blindly “correct” something that isn’t broken (edited) 

Paul  5:45 PM
Reworded as what I’d initially written was a bit confusing - I’m testing now with the master branch as I’d discovered this behaviour in a non-ADIOS2 build of my ADIOS2 branch so unsure if it’s the intended behaviour or I’ve broken something

Paul  5:55 PM
As far as I can tell, the behaviour is indeed wrong, e.g. if I run 3 timesteps, with icheckpoint=1, initstat=1 (i.e. write a checkpoint and stat file every timestep) and then do a restart with ifirst=3  my final stat files do not match the reference ones from the first run. If however I use itime=x-1 for the statistics restart also, then I get matching stats files

