### PR TITLE
Fix/bc adios2 io

### DIFF
--- a/decomp2d/io.f90
+++ b/decomp2d/io.f90
@@ -1145,7 +1145,7 @@ contains
     end if
 #else
     if (.not. engine_live(idx)) then
-       print *, "ERROR: Engine is not live!"
+       print *, "ERROR: Engine is not live!", io_name, dirname
        stop
     end if
     

--- a/examples/adios2_config.xml
+++ b/examples/adios2_config.xml
@@ -40,4 +40,12 @@
       <parameter key="ProfileUnits" value="Milliseconds"/>
     </transport>
   </io>
+  <io name="turb-io">
+    <engine type="BP4">
+    </engine>
+    <transport type="File">
+      <parameter key="Library" value="fstream"/>
+      <parameter key="ProfileUnits" value="Milliseconds"/>
+    </transport>
+  </io>
 </adios-config>

--- a/examples/adios2_config.xml
+++ b/examples/adios2_config.xml
@@ -2,11 +2,38 @@
 <adios-config>
   <io name="solution-io">
     <engine type="BP4">
-      <parameter key="Threads" value="1"/>
-      <parameter key="ProfileUnits" value="Microseconds"/>
-      <parameter key="MaxBufferSize" value="20Mb"/>
-      <parameter key="InitialBufferSize" value="1Mb"/>
-      <parameter key="BufferGrowthFactor" value="2"/>
+    </engine>
+    <transport type="File">
+      <parameter key="Library" value="fstream"/>
+      <parameter key="ProfileUnits" value="Milliseconds"/>
+    </transport>
+  </io>
+  <io name="restart-io">
+    <engine type="BP4">
+    </engine>
+    <transport type="File">
+      <parameter key="Library" value="fstream"/>
+      <parameter key="ProfileUnits" value="Milliseconds"/>
+    </transport>
+  </io>
+  <io name="statistics-io">
+    <engine type="BP4">
+    </engine>
+    <transport type="File">
+      <parameter key="Library" value="fstream"/>
+      <parameter key="ProfileUnits" value="Milliseconds"/>
+    </transport>
+  </io>
+  <io name="restart-forces-io">
+    <engine type="BP4">
+    </engine>
+    <transport type="File">
+      <parameter key="Library" value="fstream"/>
+      <parameter key="ProfileUnits" value="Milliseconds"/>
+    </transport>
+  </io>
+  <io name="BC-io">
+    <engine type="BP4">
     </engine>
     <transport type="File">
       <parameter key="Library" value="fstream"/>

--- a/src/BC-Lock-exchange.f90
+++ b/src/BC-Lock-exchange.f90
@@ -275,12 +275,14 @@ contains
   subroutine visu_lockexch_init(visu_initialised)
 
     use decomp_2d, only : mytype
-    use decomp_2d_io, only : decomp_2d_register_variable
+    use decomp_2d_io, only : decomp_2d_register_variable, decomp_2d_init_io
     
     implicit none
 
     logical, intent(out) :: visu_initialised
 
+    call decomp_2d_init_io(io_bcle)
+    
     call decomp_2d_register_variable(io_bcle, "dissm", 3, 0, 3, mytype)
     call decomp_2d_register_variable(io_bcle, "dep", 2, 0, 2, mytype)
 

--- a/src/module_param.f90
+++ b/src/module_param.f90
@@ -523,6 +523,10 @@ module param
   real(mytype),parameter :: twopi=two*acos(-one)
 #endif
 
+  !! I/O
+  character(len=*), parameter, public :: io_bc = "BC-io"
+  character(len=*), parameter, public :: bc_dir = "data-BC"
+
 end module param
 !############################################################################
 !############################################################################

--- a/src/parameters.f90
+++ b/src/parameters.f90
@@ -63,6 +63,7 @@ subroutine parameter(input_i3d)
   character(len=80), intent(in) :: input_i3d
   real(mytype) :: theta, cfl,cf2
   integer :: longueur ,impi,j, is, total
+  integer :: ierr
 
   NAMELIST /BasicParam/ p_row, p_col, nx, ny, nz, istret, beta, xlx, yly, zlz, &
        itype, iin, re, u1, u2, init_noise, inflow_noise, &

--- a/src/tools.f90
+++ b/src/tools.f90
@@ -67,7 +67,8 @@ contains
     real(mytype) :: phimax,phimin,phimax1,phimin1
     real(mytype),dimension(xsize(1),xsize(2),xsize(3),numscalar) :: phi
     real(mytype),dimension(2,numscalar) :: phimaxin,phimaxout
-
+    character(len=30) :: varname
+    
     do is=1, numscalar
 
       ta1(:,:,:) = phi(:,:,:,is)
@@ -90,7 +91,8 @@ contains
         phimin1 = -phimaxout(1,is)
         phimax1 =  phimaxout(2,is)
 
-        write(*,*) 'Phi'//char(48+is)//' min max=', real(phimin1,4), real(phimax1,4)
+        write(varname, "('Phi', I2.2)") is
+        write(*,*) varname//" min max = ", real(phimin1,4), real(phimax1,4)
 
         if (abs_prec(phimax1) > 100._mytype) then !if phi control turned off
            write(*,*) 'Scalar diverged! SIMULATION IS STOPPED!'

--- a/src/visu.f90
+++ b/src/visu.f90
@@ -285,7 +285,7 @@ contains
     ! Write scalars
     if (iscalar.ne.0) then
       do is = 1, numscalar
-        write(scname,"('phi',I2.2)") is
+        write(scname,"('phi',A)") char(48+is)
         call write_field(phi1(:,:,:,is), ".", trim(scname), trim(num), .true.)
       enddo
     endif

--- a/src/visu.f90
+++ b/src/visu.f90
@@ -75,6 +75,7 @@ contains
     integer :: noutput, nsnapout
     real(mytype) :: memout
 
+    character(len=30) :: varname
     integer :: is
 
     ! HDD usage of visu module
@@ -120,7 +121,8 @@ contains
     endif
     if (iscalar.ne.0) then
        do is = 1, numscalar
-          call decomp_2d_register_variable(io_name, "phi"//char(48+is), 1, 0, output2D, mytype)
+          write(varname, "('phi',I2.2)") is
+          call decomp_2d_register_variable(io_name, trim(varname), 1, 0, output2D, mytype)
        enddo
     endif
     
@@ -285,7 +287,7 @@ contains
     ! Write scalars
     if (iscalar.ne.0) then
       do is = 1, numscalar
-        write(scname,"('phi',A)") char(48+is)
+        write(scname,"('phi',I2.2)") is
         call write_field(phi1(:,:,:,is), ".", trim(scname), trim(num), .true.)
       enddo
     endif

--- a/src/xcompact3d.f90
+++ b/src/xcompact3d.f90
@@ -303,6 +303,7 @@ subroutine finalise_xcompact3d()
   use param, only : itype
   use probes, only : finalize_probes
   use visu, only : visu_finalise
+  use case, only : visu_case_finalise
 
   implicit none
 
@@ -322,6 +323,7 @@ subroutine finalise_xcompact3d()
   call simu_stats(4)
   call finalize_probes()
   call visu_finalise()
+  call visu_case_finalise()
   call decomp_2d_io_finalise()
   call decomp_2d_finalize
   CALL MPI_FINALIZE(ierr)

--- a/src/xcompact3d.f90
+++ b/src/xcompact3d.f90
@@ -300,11 +300,12 @@ subroutine finalise_xcompact3d()
   use decomp_2d_io, only : decomp_2d_io_finalise
 
   use tools, only : simu_stats
-  use param, only : itype
+  use param, only : itype, jles
   use probes, only : finalize_probes
   use visu, only : visu_finalise
   use case, only : visu_case_finalise
-
+  use les, only : finalise_explicit_les
+  
   implicit none
 
   integer :: ierr
@@ -324,6 +325,9 @@ subroutine finalise_xcompact3d()
   call finalize_probes()
   call visu_finalise()
   call visu_case_finalise()
+  if (jles > 0) then
+     call finalise_explicit_les()
+  end if
   call decomp_2d_io_finalise()
   call decomp_2d_finalize
   CALL MPI_FINALIZE(ierr)


### PR DESCRIPTION
Cmake/CTest identified ADIOS2 was not working when some cases performed I/O outside visu (BC-Lockexchange) and also when explicit turbulence models output their turbulent viscosity field - this PR fixes these issues