### PR TITLE
Add BUILD variable to Makefile to control debug/release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,8 @@ IVER = 17# 15,16,17,18
 CMP = gcc# intel,gcc
 FFT = generic# generic,fftw3,mkl
 
+BUILD ?=
+
 #######CMP settings###########
 ifeq ($(CMP),intel)
 FC = mpiifort
@@ -24,8 +26,13 @@ FFLAGS = -fpp -O3 -xSSE4.2 -axAVX,CORE-AVX-I,CORE-AVX2 -ipo -fp-model fast=2 -mc
 else ifeq ($(CMP),gcc)
 FC = mpif90
 #FFLAGS = -O3 -funroll-loops -floop-optimize -g -Warray-bounds -fcray-pointer -x f95-cpp-input
-FFLAGS = -cpp -O3 -funroll-loops -floop-optimize -g -Warray-bounds -fcray-pointer -fbacktrace -ffree-line-length-none
-#-ffpe-trap=invalid,zero
+ifeq ($(BUILD),debug)
+FFLAGS = -cpp -g3 -Og
+FFLAGS += -ffpe-trap=invalid,zero -fcheck=bounds
+else
+FFLAGS = -cpp -O3 -funroll-loops -floop-optimize -g
+endif
+FFLAGS += -Warray-bounds -fcray-pointer -fbacktrace -ffree-line-length-none
 ifeq "$(shell expr `gfortran -dumpversion | cut -f1 -d.` \>= 10)" "1"
 FFLAGS += -fallow-argument-mismatch
 endif


### PR DESCRIPTION
Any value other than debug will make a release build - defined as
the currently standard FFLAGS - release build is the default.

BUILD=debug will build with -g3 -Og and enable expensive (runtime)
checks such as floating point exceptions and bounds checking