### PR TITLE
Use implicit none in variables.f90

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ FC = mpif90
 #FFLAGS = -O3 -funroll-loops -floop-optimize -g -Warray-bounds -fcray-pointer -x f95-cpp-input
 ifeq ($(BUILD),debug)
 FFLAGS = -cpp -g3 -Og
-FFLAGS += -ffpe-trap=invalid,zero -fcheck=bounds
+FFLAGS += -ffpe-trap=invalid,zero -fcheck=bounds -fimplicit-none
 else
 FFLAGS = -cpp -O3 -funroll-loops -floop-optimize -g
 endif

--- a/src/statistics.f90
+++ b/src/statistics.f90
@@ -279,9 +279,9 @@ contains
 
     if (flag_read) then
        ! There was a check for nvisu = 1 before
-       call decomp_2d_read_one(1, array, stat_dir, filename, io_statistics)
+       call decomp_2d_read_one(1, array, stat_dir, filename, io_statistics, reduce_prec=.false.)
     else
-       call decomp_2d_write_one(1, array, stat_dir, filename, 1, io_statistics)
+       call decomp_2d_write_one(1, array, stat_dir, filename, 1, io_statistics, reduce_prec=.false.)
     endif
 
   end subroutine read_or_write_one_stat

--- a/src/variables.f90
+++ b/src/variables.f90
@@ -36,6 +36,8 @@ module var
   USE variables
   USE param
   USE complex_geometry
+
+  implicit none
   
   ! define all major arrays here
   real(mytype), save, allocatable, dimension(:,:,:) :: ux1, ux2, ux3, po3, dv3
@@ -110,6 +112,8 @@ contains
 
     TYPE(DECOMP_INFO), save :: ph! decomposition object
 
+    integer :: i, j, k
+    
 #ifdef DEBG
     if (nrank == 0) write(*,*) '# Init_variables start'
 #endif
@@ -177,9 +181,9 @@ contains
     call alloc_x(ti1)
     ti1 = zero
     call alloc_x(di1)
-    tdi1 = zero
+    di1 = zero
     call alloc_x(ep1)
-    tep1 = zero
+    ep1 = zero
     if (ilmn) then
       call alloc_x(mu1, opt_global=.true.)
       mu1 = one
@@ -329,7 +333,7 @@ contains
     call alloc_y(uy2)
     uy2=zero
     call alloc_y(uz2)
-    uzj2=zero
+    uz2=zero
     call alloc_y(ta2)
     ta2=zero
     call alloc_y(tb2)


### PR DESCRIPTION
Uncovered i,j,k being used as implicit variables and some arrays not zeroed correctly (typos).