### PR TITLE
Increase integer width in snapshot filename format

### DIFF
--- a/src/visu.f90
+++ b/src/visu.f90
@@ -44,7 +44,7 @@ module visu
   !        3 for 2D output with Z average
   integer, save :: output2D
   integer :: ioxdmf
-  character(len=9) :: ifilenameformat = '(I3.3)'
+  character(len=9) :: ifilenameformat = '(I7.7)'
   real, save :: tstart, tend
 
   character(len=*), parameter :: io_name = "solution-io"


### PR DESCRIPTION
Currently the integer width in the snapshot filename format is 3. This only permits integers up to a value of 999. However, this is insufficient when restarting a simulation from a large time step with a high temporal resolution for writing out the snapshots. This PR increases the integer width in the snapshot filename to 7 (permitting up to 9999999). This is the same as what is already used for the statistics filenames.