### PR TITLE
Make restarts safer by introducing a validation step

### DIFF
--- a/src/tools.f90
+++ b/src/tools.f90
@@ -1005,9 +1005,9 @@ contains
 
   ! Subroutine to rename a file/directory
   !
-  ! [string, in]           oldname  - name of existing file
-  ! [string, in]           newname  - existing file to be renamed as
-  ! [string, in, optional] opt_rank - which rank should perform the operation? all others will wait.
+  ! [string, in]            oldname  - name of existing file
+  ! [string, in]            newname  - existing file to be renamed as
+  ! [integer, in, optional] opt_rank - which rank should perform the operation? all others will wait.
   subroutine rename(oldname, newname, opt_rank)
 
     use MPI
@@ -1051,8 +1051,8 @@ contains
 
   ! Subroutine to delete a file/director
   !
-  ! [string, in]           name     - name of file to delete
-  ! [string, in, optional] opt_rank - which rank should perform the operation? all others will wait.
+  ! [string, in]            name     - name of file to delete
+  ! [integer, in, optional] opt_rank - which rank should perform the operation? all others will wait.
   subroutine delete_filedir(name, opt_rank)
 
     use MPI
@@ -1099,6 +1099,12 @@ contains
     
   end subroutine delete_filedir
 
+  ! Relatively crude validation function, checks that old and new checkpoints are the same size.
+  ! XXX: for ADIOS2/BP4 this isn't really correct/useful as it's a directory...
+  !
+  ! [string, in]            refname  - name of previous checkpoint
+  ! [string, in]            testname - name of new checkpoint
+  ! [integer, in, optional] opt_rank - which rank should perform the operation? all others will wait.
   logical function validate_restart(refname, testname, opt_rank)
 
     use MPI

--- a/src/tools.f90
+++ b/src/tools.f90
@@ -1065,8 +1065,10 @@ contains
     logical :: exist
     integer :: unit
 
-    integer :: ierror
+    character(len=:), allocatable :: cmd
 
+    integer :: ierror
+    
     if (present(opt_rank)) then
        exe_rank = opt_rank
     else
@@ -1076,9 +1078,16 @@ contains
     if (nrank == exe_rank) then
        inquire(file=name, exist=exist)
        if (exist) then
-          ! Open file so it can be deleted on close
-          open(newunit=unit, file=name)
-          close(unit, status='delete')
+          inquire(file=name//"/.", exist=exist)
+          if (.not. exist) then
+             ! Open file so it can be deleted on close
+             open(newunit=unit, file=name)
+             close(unit, status='delete')
+          else
+             ! Directory - hopefully rm should work...
+             cmd = "rm -r "//name
+             call execute_command_line(cmd)
+          end if
        end if
     end if
 


### PR DESCRIPTION
Currently the restart procedure overwrites the old restart, this pull request changes this to

1) rename old restart temporarily
2) write new restart
3) validate new restart
4) if successful, delete old restart