### PR TITLE
Build and cache OpenMPI

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -22,10 +22,25 @@ jobs:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v2
 
-    # Runs a single command using the runners shell
-    - name: Install requirements
+    # We don't want to build openmpi each time this workflow is
+    # run. Setup caching of OpenMPI after it is built and installed.
+    # See "Caching dependencies to speed up workflows" on the GH
+    # actions docs.
+    - name: Cache OpenMPI
+      id: cache-openmpi
+      uses: actions/cache@v2
+      with:
+        path: openmpi-4.1.2/installed
+        key: openmpi-4.1.2
+
+    - name: Build openmpi
+      if: steps.cache-openmpi.outputs.cache-hit != 'true'
       run: |
-        sudo apt-get update; sudo apt-get install -y gfortran openmpi-bin libopenmpi-dev
+        wget https://download.open-mpi.org/release/open-mpi/v4.1/openmpi-4.1.2.tar.gz
+        tar -xf openmpi-4.1.2.tar.gz
+        cd openmpi-4.1.2/ && mkdir installed
+        ./configure --prefix=$(pwd)/installed
+        make all install
 
     # Runs a set of commands using the runners shell
     - name: Compile

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -42,6 +42,7 @@ jobs:
         ./configure --prefix=$(pwd)/installed
         make all install
 
-    # Runs a set of commands using the runners shell
-    - name: Compile
-      run: make BUILD=debug
+    - name: Build Incompact3d
+      run: |
+        export PATH=$(pwd)/openmpi-4.1.2/installed/bin/:$PATH
+        make BUILD=debug

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -30,19 +30,19 @@ jobs:
       id: cache-openmpi
       uses: actions/cache@v2
       with:
-        path: openmpi-4.1.2/installed
-        key: openmpi-4.1.2
+        path: openmpi-4.1.4/installed
+        key: openmpi-4.1.4
 
     - name: Build openmpi
       if: steps.cache-openmpi.outputs.cache-hit != 'true'
       run: |
-        wget https://download.open-mpi.org/release/open-mpi/v4.1/openmpi-4.1.2.tar.gz
-        tar -xf openmpi-4.1.2.tar.gz
-        cd openmpi-4.1.2/ && mkdir installed
+        wget https://download.open-mpi.org/release/open-mpi/v4.1/openmpi-4.1.4.tar.gz
+        tar -xf openmpi-4.1.4.tar.gz
+        cd openmpi-4.1.4/ && mkdir installed
         ./configure --prefix=$(pwd)/installed
         make all install
 
     - name: Build Incompact3d
       run: |
-        export PATH=$(pwd)/openmpi-4.1.2/installed/bin/:$PATH
+        export PATH=$(pwd)/openmpi-4.1.4/installed/bin/:$PATH
         make BUILD=debug


### PR DESCRIPTION
The current build workflow installs OpenMPI from the Ubuntu package repository. This means that the installed OpenMPI version will change in time.

This PR pins the openmpi version by downloading and building a specific version. It is cached so that further builds do not have to go through compilation of OpenMPI (~15min) all over again. See [Caching dependencies to speed up workflows.](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows)