### PR TITLE
Add a GH actions workflow to generate reference TGV output data

### DIFF
--- a/.github/workflows/generate_reference_test_data.yml
+++ b/.github/workflows/generate_reference_test_data.yml
@@ -27,6 +27,16 @@ jobs:
         cd openmpi-4.1.2/ && mkdir installed
         ./configure --prefix=$(pwd)/installed
         make all install
+    - name: Record metadata
+      run: |
+        echo $(date) > metadata.txt
+        echo "Incompact3d HEAD: $(git rev-parse HEAD)" >> metadata.txt
+        echo "make cmd: make" >> metadata.txt
+        echo "run cmd: mpirun -np 2 xcompact3d" >> metadata.txt
+        export PATH=$(pwd)/openmpi-4.1.2/installed/bin/:$PATH
+        echo "mpif90 version: $(mpif90 --version | head -1)" >> metadata.txt
+        echo "mpirun version: $(mpirun --version | head -1)" >> metadata.txt
+        mv metadata.txt test/data/Taylor-Green-Vortex/
     - name: Build Incompact3d and run TGV reference test case
       run: |
         export PATH=$(pwd)/openmpi-4.1.2/installed/bin/:$PATH
@@ -42,5 +52,5 @@ jobs:
         title: Update reference output TGV data
         commit-message: Update reference TGV data and metadata
         add-paths: |
-          test/data/Taylor-Green-Vortex/reference_input.i3d
-          test/data/Taylor-Green-Vortex/versions.txt
+          test/data/Taylor-Green-Vortex/reference_time_evol.dat
+          test/data/Taylor-Green-Vortex/metadata.txt

--- a/.github/workflows/generate_reference_test_data.yml
+++ b/.github/workflows/generate_reference_test_data.yml
@@ -1,0 +1,46 @@
+name: "Generate reference test data"
+
+on:
+  workflow_dispatch
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    # We don't want to build openmpi each time this workflow is
+    # run. Setup caching of OpenMPI after it is built and installed.
+    # See "Caching dependencies to speed up workflows" on the GH
+    # actions docs.
+    - name: Cache OpenMPI
+      id: cache-openmpi
+      uses: actions/cache@v2
+      with:
+        path: openmpi-4.1.2/installed
+        key: openmpi-4.1.2
+    - name: Build openmpi
+      if: steps.cache-openmpi.outputs.cache-hit != 'true'
+      run: |
+        wget https://download.open-mpi.org/release/open-mpi/v4.1/openmpi-4.1.2.tar.gz
+        tar -xf openmpi-4.1.2.tar.gz
+        cd openmpi-4.1.2/ && mkdir installed
+        ./configure --prefix=$(pwd)/installed
+        make all install
+    - name: Build Incompact3d and run TGV reference test case
+      run: |
+        export PATH=$(pwd)/openmpi-4.1.2/installed/bin/:$PATH
+        make
+        cp test/data/Taylor-Green-Vortex/reference_input.i3d input.i3d
+        mpirun -np 2 xcompact3d
+    - name: Store new reference output
+      run: |
+        cp -v time_evol.dat test/data/Taylor-Green-Vortex/reference_time_evol.dat
+    - name: Create new Pull Request updating the reference output
+      uses: peter-evans/create-pull-request@v4
+      with:
+        title: Update reference output TGV data
+        commit-message: Update reference TGV data and metadata
+        add-paths: |
+          test/data/Taylor-Green-Vortex/reference_input.i3d
+          test/data/Taylor-Green-Vortex/versions.txt

--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,6 @@
 *.png
 *.svg
 *.swp
-*.dat
 *~
 sauve*
 incompact3d

--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,6 @@
 sauve*
 incompact3d
 xcompact3d
-data/
 out/
 stats/
 planes/
@@ -30,7 +29,6 @@ lint.txt
 docs/_build/
 build*
 Test*
-test*
 .cproject
 .project
 .settings

--- a/test/data/Taylor-Green-Vortex/reference_input.i3d
+++ b/test/data/Taylor-Green-Vortex/reference_input.i3d
@@ -1,0 +1,109 @@
+! -*- mode: f90 -*-
+
+!===================
+&BasicParam
+!===================
+
+! Flow type (1=Lock-exchange, 2=TGV, 3=Channel, 4=Periodic hill, 5=Cylinder, 6=dbg-schemes)
+itype = 2
+
+! Domain decomposition
+p_row=0               ! Row partition
+p_col=0               ! Column partition
+
+! Mesh
+nx=65                 ! X-direction nodes
+ny=65                 ! Y-direction nodes
+nz=65                 ! Z-direction nodes
+istret = 0            ! y mesh refinement (0:no, 1:center, 2:both sides, 3:bottom)
+beta = 0.259065151    ! Refinement parameter (beta)
+
+! Domain
+xlx = 3.14159265358979 ! Lx (Size of the box in x-direction)
+yly = 3.14159265358979 ! Ly (Size of the boy in y-direction)
+zlz = 3.14159265358979 ! Lz (Size of the boz in z-direction)
+
+! Boundary conditions
+nclx1 = 1
+nclxn = 1
+ncly1 = 1
+nclyn = 1
+nclz1 = 1
+nclzn = 1
+
+! Flow parameters
+iin = 1               ! Inflow conditions (1: classic, 2: turbinit)
+re = 1600.            ! nu=1/re (Kinematic Viscosity)
+u1 = 8.               ! u1 (max velocity) (for inflow condition)
+u2 = 8.               ! u2 (min velocity) (for inflow condition)
+init_noise  = 0.0     ! Turbulence intensity (1=100%) !! Initial condition
+inflow_noise = 0.0    ! Turbulence intensity (1=100%) !! Inflow condition
+
+! Time stepping
+dt = 0.005            ! Time step
+ifirst = 1            ! First iteration
+ilast = 4000          ! Last iteration
+
+! Enable modelling tools
+ilesmod=0             ! if 0 then DNS
+iscalar=0             ! If iscalar=0 (no scalar), if iscalar=1 (scalar)
+iibm=0                ! Flag for immersed boundary method
+
+! Enable io
+ivisu=1               ! Store snapshots
+ipost=1               ! Do online postprocessing
+
+/End
+
+!====================
+&NumOptions
+!====================
+
+! Spatial derivatives
+ifirstder = 4         ! (1->2nd central, 2->4th central, 3->4th compact, 4-> 6th compact)
+isecondder = 4        ! (1->2nd central, 2->4th central, 3->4th compact, 4-> 6th compact, 5->hyperviscous 6th)
+
+! Time scheme
+itimescheme = 5       ! Time integration scheme (1->Euler,2->AB2, 3->AB3, 4->AB4,5->RK3,6->RK4)
+
+/End
+
+!=================
+&InOutParam
+!=================
+
+! Basic I/O
+irestart = 0          ! Read initial flow field ?
+icheckpoint = 1000    ! Frequency for writing backup file
+ioutput = 1000        ! Frequency for visualization
+ilist = 5             ! Frequency for the output
+nvisu = 1             ! Size for visualisation collection
+
+/End
+
+!=================
+&Statistics
+!=================
+
+nstat = 1             ! Size arrays for statistic collection
+
+/End
+
+!#######################
+! OPTIONAL PARAMETERS
+!#######################
+
+!=================
+&LESModel
+!=================
+jles=1
+smagcst=0.1
+walecst=0.5
+iwall=0
+/End
+
+!=================
+&CASE
+!=================
+tgv_twod = .FALSE.
+/End


### PR DESCRIPTION
This adds a GitHub actions workflow to generate reference output data for the currently implemented Taylor-Green vortex flow case [`input_DNS_Re1600.i3d`](https://github.com/xcompact3d/Incompact3d/blob/master/examples/Taylor-Green-Vortex/input_DNS_Re1600.i3d). This data will then be used to test output of future versions of Incompact3d, see #122 .

Reference data is generated as `test/data/Taylor-Green-Vortex/reference_time_evol.dat`, alongside with file `metadata.txt` that contains information required to reproduce the build and production of the data, e.g. 

```
# test/data/Taylor-Green-Vortex/metadata.txt
Thu Oct 20 14:34:25 UTC 2022
Incompact3d HEAD: 0cb9546526633b2f913a6a143a0f58753aa1b6e3
make cmd: make
run cmd: mpirun -np 2 xcompact3d
mpif90 version: GNU Fortran (Ubuntu 9.4.0-1ubuntu1~20.04.1) 9.4.0
mpirun version: mpirun (Open MPI) 4.1.2
```

The action is to be triggered manually from the GitHub UI, from the _Actions_ panel. For more info about running actions manually, see [`workflow_dispatch`](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch) on the GitHub Actions docs.

Upon execution, the workflow goes through the following steps:
1. Builds and caches OpenMPI (in the same way that #121 does).
2. Builds Incompact3d.
3. Runs the `xcompact3d` executable on reference input file `reference_input.i3d`.
4. Runs the `compare_TGV_time_evolution.py` script to compare
   generated output to reference output.