### PR TITLE
maxval debug

### DIFF
--- a/src/BC-Channel-flow.f90
+++ b/src/BC-Channel-flow.f90
@@ -29,10 +29,6 @@ contains
     use param
     use MPI
     use dbg_schemes, only: exp_prec, abs_prec, sqrt_prec
-#ifdef DEBG 
-    use tools, only : avg3d
-#endif
-    
 
     implicit none
 
@@ -57,10 +53,6 @@ contains
     real(mytype), dimension(3) :: dim_min, dim_max
     real( kind = 8 ) :: r8_random
     external r8_random, return_30k
-#ifdef DEBG 
-    real(mytype) avg_param
-#endif
-
 
     if (idir_stream /= 1 .and. idir_stream /= 3) then
        if (nrank == 0) then
@@ -249,19 +241,6 @@ contains
           enddo
        enddo
     enddo
-
-#ifdef DEBG
-    avg_param = zero
-    call avg3d (ux1, avg_param)
-    if (nrank == 0) write(*,*)'## SUB Channel Init ux_avg ', avg_param
-    avg_param = zero
-    call avg3d (uy1, avg_param)
-    if (nrank == 0) write(*,*)'## SUB Channel Init uy_avg ', avg_param
-    avg_param = zero
-    call avg3d (uz1, avg_param)
-    if (nrank == 0) write(*,*)'## SUB Channel Init uz_avg ', avg_param
-    if (nrank .eq. 0) write(*,*) '# init end ok'
-#endif
 
     return
   end subroutine init_channel

--- a/src/navier.f90
+++ b/src/navier.f90
@@ -22,13 +22,14 @@ contains
   !############################################################################
   SUBROUTINE solve_poisson(pp3, px1, py1, pz1, rho1, ux1, uy1, uz1, ep1, drho1, divu3)
 
-    USE decomp_2d, ONLY : mytype, xsize, zsize, ph1, nrank
+    USE decomp_2d, ONLY : mytype, xsize, zsize, ph1, nrank, real_type
     USE decomp_2d_poisson, ONLY : poisson
     USE var, ONLY : nzmsize
     USE var, ONLY : dv3
     USE param, ONLY : ntime, nrhotime, npress
     USE param, ONLY : ilmn, ivarcoeff, zero, one 
-
+    USE mpi
+    
     implicit none
 
     !! Inputs
@@ -47,7 +48,8 @@ contains
     LOGICAL :: converged
     REAL(mytype) :: atol, rtol, rho0, divup3norm
 #ifdef DEBG
-    real(mytype) avg_param
+    real(mytype) :: dep, dep1
+    integer :: code
 #endif
 
     nlock = 1 !! Corresponds to computing div(u*)
@@ -88,32 +90,32 @@ contains
 
        IF (.NOT.converged) THEN
 #ifdef DEBG
-          avg_param = zero
-          call avg3d (pp3(:,:,:,1), avg_param)
-          if (nrank == 0) write(*,*)'## Solve Poisson before1 pp3', avg_param
+          dep=maxval(abs(pp3(:,:,:,1)))
+          call MPI_ALLREDUCE(dep,dep1,1,real_type,MPI_MAX,MPI_COMM_WORLD,code)
+          if (nrank == 0) write(*,*)'## Solve Poisson before1 pp3', dep1
 #endif
           CALL poisson(pp3(:,:,:,1))
 #ifdef DEBG
-          avg_param = zero
-          call avg3d (pp3(:,:,:,1), avg_param)
-          if (nrank == 0) write(*,*)'## Solve Poisson after call  pp3', avg_param
+          dep=maxval(abs(pp3(:,:,:,1)))
+          call MPI_ALLREDUCE(dep,dep1,1,real_type,MPI_MAX,MPI_COMM_WORLD,code)
+          if (nrank == 0) write(*,*)'## Solve Poisson after call  pp3', dep1
 #endif
 
           !! Need to update pressure gradient here for varcoeff
           CALL gradp(px1,py1,pz1,pp3(:,:,:,1))
 #ifdef DEBG
-          avg_param = zero
-          call avg3d (pp3(:,:,:,1), avg_param)
-          if (nrank == 0) write(*,*)'## Solve Poisson pp3', avg_param
-          avg_param = zero
-          call avg3d (px1, avg_param)
-          if (nrank == 0) write(*,*)'## Solve Poisson px', avg_param
-          avg_param = zero
-          call avg3d (py1, avg_param)
-          if (nrank == 0) write(*,*)'## Solve Poisson py', avg_param
-          avg_param = zero
-          call avg3d (pz1, avg_param)
-          if (nrank == 0) write(*,*)'## Solve Poisson pz', avg_param
+          dep=maxval(abs(pp3(:,:,:,1)))
+          call MPI_ALLREDUCE(dep,dep1,1,real_type,MPI_MAX,MPI_COMM_WORLD,code)
+          if (nrank == 0) write(*,*)'## Solve Poisson pp3', dep1
+          dep=maxval(abs(px1))
+          call MPI_ALLREDUCE(dep,dep1,1,real_type,MPI_MAX,MPI_COMM_WORLD,code)
+          if (nrank == 0) write(*,*)'## Solve Poisson px', dep1
+          dep=maxval(abs(py1))
+          call MPI_ALLREDUCE(dep,dep1,1,real_type,MPI_MAX,MPI_COMM_WORLD,code)
+          if (nrank == 0) write(*,*)'## Solve Poisson py', dep1
+          dep=maxval(abs(pz1))
+          call MPI_ALLREDUCE(dep,dep1,1,real_type,MPI_MAX,MPI_COMM_WORLD,code)
+          if (nrank == 0) write(*,*)'## Solve Poisson pz', dep1
 #endif
          
 
@@ -205,34 +207,36 @@ contains
     USE decomp_2d
     USE variables
     USE param
+    USE mpi
 
     implicit none
 
     real(mytype),dimension(xsize(1),xsize(2),xsize(3)) :: ux,uy,uz
     real(mytype),dimension(xsize(1),xsize(2),xsize(3)),intent(in) :: px,py,pz
 #ifdef DEBG
-    real(mytype) avg_param
+    real(mytype) :: dep, dep1
+    integer :: code
 #endif
 
 #ifdef DEBG
-    avg_param = zero
-    call avg3d (ux, avg_param)
-    if (nrank == 0) write(*,*)'## Cor Vel ux', avg_param
-    avg_param = zero
-    call avg3d (uy, avg_param)
-    if (nrank == 0) write(*,*)'## Cor Vel uy', avg_param
-    avg_param = zero
-    call avg3d (uz, avg_param)
-    if (nrank == 0) write(*,*)'## Cor Vel uz', avg_param
-    avg_param = zero
-    call avg3d (px, avg_param)
-    if (nrank == 0) write(*,*)'## Cor Vel px', avg_param
-    avg_param = zero
-    call avg3d (py, avg_param)
-    if (nrank == 0) write(*,*)'## Cor Vel py', avg_param
-    avg_param = zero
-    call avg3d (pz, avg_param)
-    if (nrank == 0) write(*,*)'## Cor Vel pz', avg_param
+        dep=maxval(abs(ux))
+    call MPI_ALLREDUCE(dep,dep1,1,real_type,MPI_MAX,MPI_COMM_WORLD,code)
+    if (nrank == 0) write(*,*)'## Cor Vel ux', dep1
+        dep=maxval(abs(uy))
+    call MPI_ALLREDUCE(dep,dep1,1,real_type,MPI_MAX,MPI_COMM_WORLD,code)
+    if (nrank == 0) write(*,*)'## Cor Vel uy', dep1
+        dep=maxval(abs(uz))
+    call MPI_ALLREDUCE(dep,dep1,1,real_type,MPI_MAX,MPI_COMM_WORLD,code)
+    if (nrank == 0) write(*,*)'## Cor Vel uz', dep1
+        dep=maxval(abs(px))
+    call MPI_ALLREDUCE(dep,dep1,1,real_type,MPI_MAX,MPI_COMM_WORLD,code)
+    if (nrank == 0) write(*,*)'## Cor Vel px', dep1
+        dep=maxval(abs(py))
+    call MPI_ALLREDUCE(dep,dep1,1,real_type,MPI_MAX,MPI_COMM_WORLD,code)
+    if (nrank == 0) write(*,*)'## Cor Vel py', dep1
+        dep=maxval(abs(pz))
+    call MPI_ALLREDUCE(dep,dep1,1,real_type,MPI_MAX,MPI_COMM_WORLD,code)
+    if (nrank == 0) write(*,*)'## Cor Vel pz', dep1
 #endif
 
     ux(:,:,:)=ux(:,:,:)-px(:,:,:)
@@ -513,7 +517,7 @@ contains
     integer, dimension(2) :: dims, dummy_coords
     logical, dimension(2) :: dummy_periods
 #ifdef DEBG
-    real(mytype) avg_param
+    real(mytype) dep, dep1
 #endif
 
     call MPI_CART_GET(DECOMP_2D_COMM_CART_X, 2, dims, dummy_periods, dummy_coords, code)
@@ -725,15 +729,15 @@ contains
        endif
     endif
 #ifdef DEBG
-    avg_param = zero
-    call avg3d (ux, avg_param)
-    if (nrank == 0) write(*,*)'## Pres corr ux ', avg_param
-    avg_param = zero
-    call avg3d (uy, avg_param)
-    if (nrank == 0) write(*,*)'## Pres corr uy ', avg_param
-    avg_param = zero
-    call avg3d (uz, avg_param)
-    if (nrank == 0) write(*,*)'## Pres corr uz ', avg_param
+    dep=maxval(abs(ux))
+    call MPI_ALLREDUCE(dep,dep1,1,real_type,MPI_MAX,MPI_COMM_WORLD,code)
+    if (nrank == 0) write(*,*)'## Pres corr ux ', dep1
+    dep=maxval(abs(uy))
+    call MPI_ALLREDUCE(dep,dep1,1,real_type,MPI_MAX,MPI_COMM_WORLD,code)
+    if (nrank == 0) write(*,*)'## Pres corr uy ', dep1
+    dep=maxval(abs(uz))
+    call MPI_ALLREDUCE(dep,dep1,1,real_type,MPI_MAX,MPI_COMM_WORLD,code)
+    if (nrank == 0) write(*,*)'## Pres corr uz ', dep1
 #endif
 
     if (iibm==1) then !solid body old school
@@ -1276,76 +1280,5 @@ contains
     enddo
 
   end subroutine tbl_flrt
-!############################################################################
-!!
-!!  SUBROUTINE: avg3d
-!!      AUTHOR: Stefano Rolfo
-!! DESCRIPTION: Compute the total sum of a a 3d field
-!!
-!############################################################################
-subroutine avg3d (var, avg)
-
-  use decomp_2d, only: real_type, xsize, xend
-  use param
-  use dbg_schemes, only: sqrt_prec
-  use variables, only: nx,ny,nz,nxm,nym,nzm
-  use mpi
-
-  implicit none
-
-  real(mytype),dimension(xsize(1),xsize(2),xsize(3)),intent(in) :: var
-  real(mytype), intent(out) :: avg
-  real(mytype)              :: dep
-
-  integer :: i,j,k, code
-  integer :: nxc, nyc, nzc, xsize1, xsize2, xsize3
-
-  if (nclx1==1.and.xend(1)==nx) then
-     xsize1=xsize(1)-1
-  else
-     xsize1=xsize(1)
-  endif
-  if (ncly1==1.and.xend(2)==ny) then
-     xsize2=xsize(2)-1
-  else
-     xsize2=xsize(2)
-  endif
-  if (nclz1==1.and.xend(3)==nz) then
-     xsize3=xsize(3)-1
-  else
-     xsize3=xsize(3)
-  endif
-  if (nclx1==1) then
-     nxc=nxm
-  else
-     nxc=nx
-  endif
-  if (ncly1==1) then
-     nyc=nym
-  else
-     nyc=ny
-  endif
-  if (nclz1==1) then
-     nzc=nzm
-  else
-     nzc=nz
-  endif
-
-  dep=zero
-  do k=1,xsize3
-     do j=1,xsize2
-        do i=1,xsize1
-           !dep=dep+var(i,j,k)**2
-           dep=dep+var(i,j,k)
-        enddo
-     enddo
-  enddo
-  call MPI_ALLREDUCE(dep,avg,1,real_type,MPI_SUM,MPI_COMM_WORLD,code)
-  !avg=sqrt_prec(avg)/(nxc*nyc*nzc)
-  avg=avg/(nxc*nyc*nzc)
-
-  return
-
-end subroutine avg3d
 
 endmodule navier

--- a/src/poisson.f90
+++ b/src/poisson.f90
@@ -689,8 +689,6 @@ contains
     real(mytype) :: rl, iy
     external cx, rl, iy
 
-    real(mytype) :: avg_param
-
 100 format(1x,a8,3I4,2F12.6)
 
     nx = nx_global
@@ -1036,6 +1034,7 @@ contains
   subroutine poisson_11x(rhs)
 
     use dbg_schemes, only: abs_prec
+    use mpi
     
 
     implicit none
@@ -1052,7 +1051,8 @@ contains
     real(mytype) :: rl, iy
     external cx, rl, iy
 #ifdef DEBG
-    real(mytype) avg_param
+    real(mytype) :: dep, dep1
+    integer :: code
 #endif
 
 100 format(1x,a8,3I4,2F12.6)
@@ -1094,9 +1094,9 @@ contains
        end do
     end do
 #ifdef DEBG
-    avg_param = zero
-    call avg3d (rw2b, avg_param)
-    if (nrank == 0) write(*,*)'## Poisson11X Start rw2 ', avg_param
+    dep=maxval(abs(rw2b))
+    call MPI_ALLREDUCE(dep,dep1,1,real_type,MPI_SUM,MPI_COMM_WORLD,code)
+    if (nrank == 0) write(*,*)'## Poisson11X Start rw2 ', dep1
 #endif
 
     ! the global operations in X
@@ -1113,9 +1113,9 @@ contains
        end do
     end do
 #ifdef DEBG
-    avg_param = zero
-    call avg3d (rw1b, avg_param)
-    if (nrank == 0) write(*,*)'## Poisson11X Start rw1 ', avg_param
+    dep=maxval(abs(rw1b))
+    call MPI_ALLREDUCE(dep,dep1,1,real_type,MPI_SUM,MPI_COMM_WORLD,code)
+    if (nrank == 0) write(*,*)'## Poisson11X Start rw1 ', dep1
 #endif
 
     ! back to Z-pencil
@@ -1134,17 +1134,6 @@ contains
     ! normalisation
     cw1 = cw1 / real(nx, kind=mytype) /real(ny, kind=mytype) &
          / real(nz, kind=mytype)
-#ifdef DEBUG
-    do k = sp%xst(3),sp%xen(3)
-       do j = sp%xst(2),sp%xen(2)
-          do i = sp%xst(1),sp%xen(1)
-             if (abs_prec(cw1(i,j,k)) > 1.0e-4) then
-                write(*,100) 'START',i,j,k,cw1(i,j,k)
-             end if
-          end do
-       end do
-    end do
-#endif
 
     ! post-processing in spectral space
 
@@ -1156,17 +1145,13 @@ contains
              tmp2 = iy(cw1(i,j,k))
              cw1(i,j,k) = cx(tmp1 * bz(k) + tmp2 * az(k), &
                              tmp2 * bz(k) - tmp1 * az(k))
-#ifdef DEBUG
-             if (abs_prec(cw1(i,j,k)) > 1.0e-4) &
-                  write(*,100) 'after z',i,j,k,cw1(i,j,k)
-#endif
           end do
        end do
     end do
 #ifdef DEBG
-    avg_param = zero
-    call avg3d (abs(cw1), avg_param)
-    if (nrank == 0) write(*,*)'## Poisson11X Post in Z cw1 ', avg_param
+    dep=maxval(abs(cw1))
+    call MPI_ALLREDUCE(dep,dep1,1,real_type,MPI_SUM,MPI_COMM_WORLD,code)
+    if (nrank == 0) write(*,*)'## Poisson11X Post in Z cw1 ', dep1
 #endif
 
     ! POST PROCESSING IN Y
@@ -1194,26 +1179,17 @@ contains
        end do
     end do
 #ifdef DEBG
-    avg_param = zero
-    call avg3d (abs(cw2), avg_param)
-    if (nrank == 0) write(*,*)'## Poisson11X Post in Y cw2 ', avg_param
+    dep=maxval(abs(cw2))
+    call MPI_ALLREDUCE(dep,dep1,1,real_type,MPI_SUM,MPI_COMM_WORLD,code)
+    if (nrank == 0) write(*,*)'## Poisson11X Post in Y cw2 ', dep1
 #endif
 
     ! back to X-pencil
     call transpose_y_to_x(cw2b,cw1,sp)
 #ifdef DEBUG
-    do k = sp%xst(3), sp%xen(3)
-       do j = sp%xst(2), sp%xen(2)
-          do i = sp%xst(1), sp%xen(1)
-             if (abs_prec(cw1(i,j,k)) > 1.0e-4) then
-                write(*,100) 'after y',i,j,k,cw1(i,j,k)
-             end if
-          end do
-       end do
-    end do
-    avg_param = zero
-    call avg3d (cw1, avg_param)
-    if (nrank == 0) write(*,*)'## Poisson11X Back to X cw1 ', avg_param
+    dep=maxval(abs(cw1))
+    call MPI_ALLREDUCE(dep,dep1,1,real_type,MPI_SUM,MPI_COMM_WORLD,code)
+    if (nrank == 0) write(*,*)'## Poisson11X Back to X cw1 ', dep1
 #endif
 
     ! POST PROCESSING IN X
@@ -1238,20 +1214,10 @@ contains
           end do
        end do
     end do
-
 #ifdef DEBUG
-    do k = sp%xst(3), sp%xen(3)
-       do j = sp%xst(2), sp%xen(2)
-          do i = sp%xst(1), sp%xen(1)
-             if (abs_prec(cw1b(i,j,k)) > 1.0e-4) then
-                write(*,*) 'BEFORE',i,j,k,cw1b(i,j,k)
-             end if
-          end do
-       end do
-    end do
-    avg_param = zero
-    call avg3d (abs(cw1b), avg_param)
-    if (nrank == 0) write(*,*)'## Poisson11X Back to X cw1b ', avg_param
+    dep=maxval(abs(cw1b))
+    call MPI_ALLREDUCE(dep,dep1,1,real_type,MPI_SUM,MPI_COMM_WORLD,code)
+    if (nrank == 0) write(*,*)'## Poisson11X Back to X cw1b ', cw1b
 #endif
 
     if (istret == 0) then
@@ -1279,9 +1245,9 @@ contains
           end do
        end do
 #ifdef DEBUG
-       avg_param = zero
-       call avg3d (cw1b, avg_param)
-       if (nrank == 0) write(*,*)'## Poisson11X Solve Pois istret 0 ', avg_param
+       dep=maxval(abs(cw1b))
+       call MPI_ALLREDUCE(dep,dep1,1,real_type,MPI_SUM,MPI_COMM_WORLD,code)
+       if (nrank == 0) write(*,*)'## Poisson11X Solve Pois istret 0 ', dep1
 #endif
 
     else
@@ -1350,9 +1316,9 @@ contains
              enddo
           enddo
 #ifdef DEBUG
-          avg_param = zero
-          call avg3d (cw2b, avg_param)
-          if (nrank == 0) write(*,*)'## Poisson11X Solve Pois istret < 3 ', avg_param
+          dep=maxval(abs(cw2b))
+          call MPI_ALLREDUCE(dep,dep1,1,real_type,MPI_SUM,MPI_COMM_WORLD,code)
+          if (nrank == 0) write(*,*)'## Poisson11X Solve Pois istret < 3 ', dep1
 #endif
        else
           cw2 = zero
@@ -1375,27 +1341,18 @@ contains
           enddo
        endif
 #ifdef DEBUG
-          avg_param = zero
-          call avg3d (cw2b, avg_param)
-          if (nrank == 0) write(*,*)'## Poisson11X Solve Pois istret = 3 ', avg_param
+       dep=maxval(abs(cw2b))
+       call MPI_ALLREDUCE(dep,dep1,1,real_type,MPI_SUM,MPI_COMM_WORLD,code)
+       if (nrank == 0) write(*,*)'## Poisson11X Solve Pois istret = 3 ', dep1
 #endif
        !we have to go back in X pencils
        call transpose_y_to_x(cw2b,cw1b,sp)
     endif
 
 #ifdef DEBUG
-    do k = sp%xst(3),sp%xen(3)
-       do j = sp%xst(2),sp%xen(2)
-          do i = sp%xst(1),sp%xen(1)
-             if (abs_prec(cw1b(i,j,k)) > 1.0e-6) then
-                write(*,*) 'AFTER',i,j,k,cw1b(i,j,k)
-             end if
-          end do
-       end do
-    end do
-    avg_param = zero
-    call avg3d (cw1b, avg_param)
-    if (nrank == 0) write(*,*)'## Poisson11X Solve Pois AFTER ', avg_param
+    dep=maxval(abs(cw1b))
+    call MPI_ALLREDUCE(dep,dep1,1,real_type,MPI_SUM,MPI_COMM_WORLD,code)
+    if (nrank == 0) write(*,*)'## Poisson11X Solve Pois AFTER ', dep1
 #endif
     !stop
     ! post-processing backward
@@ -1422,18 +1379,9 @@ contains
        end do
     end do
 #ifdef DEBUG
-    do k = sp%xst(3), sp%xen(3)
-       do j = sp%xst(2), sp%xen(2)
-          do i = sp%xst(1), sp%xen(1)
-             if (abs_prec(cw1(i,j,k)) > 1.0e-4) then
-                write(*,100) 'AFTER X',i,j,k,cw1(i,j,k)
-             end if
-          end do
-       end do
-    end do
-    avg_param = zero
-    call avg3d (cw1, avg_param)
-    if (nrank == 0) write(*,*)'## Poisson11X Solve Pois POSTPR X ', avg_param
+    dep=maxval(abs(cw1))
+    call MPI_ALLREDUCE(dep,dep1,1,real_type,MPI_SUM,MPI_COMM_WORLD,code)
+    if (nrank == 0) write(*,*)'## Poisson11X Solve Pois POSTPR X ', dep1
 #endif
 
     ! POST PROCESSING IN Y
@@ -1461,18 +1409,9 @@ contains
        end do
     end do
 #ifdef DEBUG
-    do k = sp%yst(3), sp%yen(3)
-       do j = sp%yst(2), sp%yen(2)
-          do i = sp%yst(1), sp%yen(1)
-             if (abs_prec(cw2b(i,j,k)) > 1.0e-4) then
-                write(*,100) 'AFTER Y',i,j,k,cw2b(i,j,k)
-             end if
-          end do
-       end do
-    end do
-   avg_param = zero
-   call avg3d (abs(cw2b), avg_param)
-   if (nrank == 0) write(*,*)'## Poisson11X Solve Pois POSTPR Y ', avg_param
+    dep=maxval(abs(cw2b))
+    call MPI_ALLREDUCE(dep,dep1,1,real_type,MPI_SUM,MPI_COMM_WORLD,code)
+    if (nrank == 0) write(*,*)'## Poisson11X Solve Pois POSTPR Y ', dep1
 #endif
     ! back to X-pencil
     call transpose_y_to_x(cw2b,cw1,sp)
@@ -1485,25 +1424,21 @@ contains
              tmp2 = iy(cw1(i,j,k))
              cw1(i,j,k) = cx(tmp1 * bz(k) - tmp2 * az(k), &
                              tmp2 * bz(k) + tmp1 * az(k))
-#ifdef DEBUG
-             if (abs_prec(cw1(i,j,k)) > 1.0e-4) &
-                  write(*,100) 'END',i,j,k,cw1(i,j,k)
-#endif
           end do
        end do
     end do
 #ifdef DEBUG
-    avg_param = zero
-    call avg3d (cw1, avg_param)
-    if (nrank == 0) write(*,*)'## Poisson11X Solve Pois POSTPR Z ', avg_param
+    dep=maxval(abs(cw1))
+    call MPI_ALLREDUCE(dep,dep1,1,real_type,MPI_SUM,MPI_COMM_WORLD,code)
+    if (nrank == 0) write(*,*)'## Poisson11X Solve Pois POSTPR Z ', dep1
 #endif
 
     ! compute c2r transform, back to physical space
     call decomp_2d_fft_3d(cw1,rhs)
 #ifdef DEBUG
-    avg_param = zero
-    call avg3d (rhs, avg_param)
-    if (nrank == 0) write(*,*)'## Poisson11X Solve Pois Back Phy RHS ', avg_param
+    dep=maxval(abs(rhs))
+    call MPI_ALLREDUCE(dep,dep1,1,real_type,MPI_SUM,MPI_COMM_WORLD,code)
+    if (nrank == 0) write(*,*)'## Poisson11X Solve Pois Back Phy RHS ', dep1
 #endif
 
     if (bcz == 1) then 
@@ -2347,71 +2282,6 @@ contains
 
     return
   end subroutine matrice_refinement
-!=====================================
-subroutine avg3d (var, avg)
-
-  use decomp_2d, only: real_type, xsize, xend
-  use param
-  use dbg_schemes, only: sqrt_prec
-  use variables, only: nx,ny,nz,nxm,nym,nzm
-  use mpi
-
-  implicit none
-
-  real(mytype),dimension(xsize(1),xsize(2),xsize(3)),intent(in) :: var
-  real(mytype), intent(out) :: avg
-  real(mytype)              :: dep
-
-  integer :: i,j,k, code
-  integer :: nxc, nyc, nzc, xsize1, xsize2, xsize3
-
-  if (nclx1==1.and.xend(1)==nx) then
-     xsize1=xsize(1)-1
-  else
-     xsize1=xsize(1)
-  endif
-  if (ncly1==1.and.xend(2)==ny) then
-     xsize2=xsize(2)-1
-  else
-     xsize2=xsize(2)
-  endif
-  if (nclz1==1.and.xend(3)==nz) then
-     xsize3=xsize(3)-1
-  else
-     xsize3=xsize(3)
-  endif
-  if (nclx1==1) then
-     nxc=nxm
-  else
-     nxc=nx
-  endif
-  if (ncly1==1) then
-     nyc=nym
-  else
-     nyc=ny
-  endif
-  if (nclz1==1) then
-     nzc=nzm
-  else
-     nzc=nz
-  endif
-
-  dep=zero
-  do k=1,xsize3
-     do j=1,xsize2
-        do i=1,xsize1
-           !dep=dep+var(i,j,k)**2
-           dep=dep+var(i,j,k)
-        enddo
-     enddo
-  enddo
-  call MPI_ALLREDUCE(dep,avg,1,real_type,MPI_SUM,MPI_COMM_WORLD,code)
-  !avg=sqrt_prec(avg)/(nxc*nyc*nzc)
-  avg=avg/(nxc*nyc*nzc)
-
-  return
-
-end subroutine avg3d
 
 end module decomp_2d_poisson
 

--- a/src/tools.f90
+++ b/src/tools.f90
@@ -20,8 +20,7 @@ module tools
        simu_stats, &
        apply_spatial_filter, read_inflow, append_outflow, write_outflow, init_inflow_outflow, &
        compute_cfldiff, compute_cfl, &
-       rescale_pressure, mean_plane_x, mean_plane_y, mean_plane_z, &
-       avg3d
+       rescale_pressure, mean_plane_x, mean_plane_y, mean_plane_z
 
 contains
   !##################################################################
@@ -920,76 +919,6 @@ contains
     return
 
   end subroutine mean_plane_z
-  !############################################################################
-  !!
-  !!  SUBROUTINE: avg3d
-  !!      AUTHOR: Stefano Rolfo
-  !! DESCRIPTION: Compute the total sum of a a 3d field
-  !!
-  !############################################################################
-  subroutine avg3d (var, avg)
-
-    use decomp_2d, only: real_type, xsize, xend
-    use param
-    use variables, only: nx,ny,nz,nxm,nym,nzm
-    use mpi
-
-    implicit none
-
-    real(mytype),dimension(xsize(1),xsize(2),xsize(3)),intent(in) :: var
-    real(mytype), intent(out) :: avg
-    real(mytype)              :: dep
-
-    integer :: i,j,k, code
-    integer :: nxc, nyc, nzc, xsize1, xsize2, xsize3
-
-    if (nclx1==1.and.xend(1)==nx) then
-       xsize1=xsize(1)-1
-    else
-       xsize1=xsize(1)
-    endif
-    if (ncly1==1.and.xend(2)==ny) then
-       xsize2=xsize(2)-1
-    else
-       xsize2=xsize(2)
-    endif
-    if (nclz1==1.and.xend(3)==nz) then
-       xsize3=xsize(3)-1
-    else
-       xsize3=xsize(3)
-    endif
-    if (nclx1==1) then
-       nxc=nxm
-    else
-       nxc=nx
-    endif
-    if (ncly1==1) then
-       nyc=nym
-    else
-       nyc=ny
-    endif
-    if (nclz1==1) then
-       nzc=nzm
-    else
-       nzc=nz
-    endif
-
-    dep=zero
-    do k=1,xsize3
-       do j=1,xsize2
-          do i=1,xsize1
-             !dep=dep+var(i,j,k)**2
-             dep=dep+var(i,j,k)
-          enddo
-       enddo
-    enddo
-    call MPI_ALLREDUCE(dep,avg,1,real_type,MPI_SUM,MPI_COMM_WORLD,code)
-    avg=avg/(nxc*nyc*nzc)
-
-    return
-
-  end subroutine avg3d
-
   ! Subroutine to rename a file/directory
   !
   ! [string, in]            oldname  - name of existing file

--- a/src/transeq.f90
+++ b/src/transeq.f90
@@ -74,10 +74,7 @@ contains
     use var, only : FTx, FTy, FTz, Fdiscx, Fdiscy, Fdiscz
     use ibm_param, only : ubcx,ubcy,ubcz
     use les, only : compute_SGS
-#ifdef DEBG 
-    use tools, only : avg3d
-#endif
-
+    use mpi
 
     use case, only : momentum_forcing
 
@@ -91,12 +88,13 @@ contains
 
     !! OUTPUTS
     real(mytype),dimension(xsize(1),xsize(2),xsize(3),ntime) :: dux1,duy1,duz1
-
-#ifdef DEBG 
-    real(mytype) avg_param
-#endif
     
     integer :: i,j,k,is
+
+#ifdef DEBG 
+    real(mytype) :: dep, dep1
+    integer :: code
+#endif
 
     !SKEW SYMMETRIC FORM
     !WORK X-PENCILS
@@ -110,10 +108,10 @@ contains
       tc1(:,:,:) = ux1(:,:,:) * uz1(:,:,:)
     endif
 
-#ifdef DEBG 
-    avg_param = zero
-    call avg3d (ta1, avg_param)
-    if (nrank == 0) write(*,*)'## SUB momentum_rhs_eq VAR ta1 (uu) AVG ', avg_param
+#ifdef DEBG
+    dep=maxval(abs(ta1))
+    call MPI_ALLREDUCE(dep,dep1,1,real_type,MPI_MAX,MPI_COMM_WORLD,code)
+    if (nrank == 0) write(*,*)'## SUB momentum_rhs_eq VAR ta1 (uu) MAX ', dep1
 #endif
 
     call derx (td1,ta1,di1,sx,ffxp,fsxp,fwxp,xsize(1),xsize(2),xsize(3),1,ubcx*ubcx)
@@ -123,10 +121,10 @@ contains
     call derx (tb1,uy1,di1,sx,ffxp,fsxp,fwxp,xsize(1),xsize(2),xsize(3),1,ubcy)
     call derx (tc1,uz1,di1,sx,ffxp,fsxp,fwxp,xsize(1),xsize(2),xsize(3),1,ubcz)
 
-#ifdef DEBG 
-    avg_param = zero
-    call avg3d (ta1, avg_param)
-    if (nrank == 0) write(*,*)'## SUB momentum_rhs_eq VAR ta1 (du) AVG ', avg_param
+#ifdef DEBG
+    dep=maxval(abs(ta1))
+    call MPI_ALLREDUCE(dep,dep1,1,real_type,MPI_MAX,MPI_COMM_WORLD,code)
+    if (nrank == 0) write(*,*)'## SUB momentum_rhs_eq VAR ta1 (du) MAX ', dep1
 #endif
 
     ! Convective terms of x-pencil are stored in tg1,th1,ti1
@@ -140,10 +138,10 @@ contains
       ti1(:,:,:) = tf1(:,:,:) + ux1(:,:,:) * tc1(:,:,:)
     endif
     ! TODO: save the x-convective terms already in dux1, duy1, duz1
-#ifdef DEBG 
-    avg_param = zero
-    call avg3d (tg1, avg_param)
-    if (nrank == 0) write(*,*)'## SUB momentum_rhs_eq VAR tg1 (duu+udu) AVG ', avg_param
+#ifdef DEBG
+    dep=maxval(abs(tg1))
+    call MPI_ALLREDUCE(dep,dep1,1,real_type,MPI_MAX,MPI_COMM_WORLD,code)
+    if (nrank == 0) write(*,*)'## SUB momentum_rhs_eq VAR tg1 (duu+udu) MAX ', dep1
 #endif
 
     if (ilmn) then
@@ -157,13 +155,13 @@ contains
     call transpose_x_to_y(ux1,ux2)
     call transpose_x_to_y(uy1,uy2)
     call transpose_x_to_y(uz1,uz2)
-#ifdef DEBG 
-    avg_param = zero
-    call avg3d (ux2, avg_param)
-    if (nrank == 0) write(*,*)'## SUB momentum_rhs_eq VAR ux2 (transpose) AVG ', avg_param
-    avg_param = zero
-    call avg3d (uy2, avg_param)
-    if (nrank == 0) write(*,*)'## SUB momentum_rhs_eq VAR uy2 (transpose) AVG ', avg_param
+#ifdef DEBG
+    dep=maxval(abs(ux2))
+    call MPI_ALLREDUCE(dep,dep1,1,real_type,MPI_MAX,MPI_COMM_WORLD,code)
+    if (nrank == 0) write(*,*)'## SUB momentum_rhs_eq VAR ux2 (transpose) MAX ', dep1
+    dep=maxval(abs(uy2))
+    call MPI_ALLREDUCE(dep,dep1,1,real_type,MPI_MAX,MPI_COMM_WORLD,code)
+    if (nrank == 0) write(*,*)'## SUB momentum_rhs_eq VAR uy2 (transpose) MAX ', dep1
 #endif
 
     if (ilmn) then
@@ -183,10 +181,10 @@ contains
       te2(:,:,:) = uy2(:,:,:) * uy2(:,:,:)
       tf2(:,:,:) = uz2(:,:,:) * uy2(:,:,:)
     endif
-#ifdef DEBG 
-    avg_param = zero
-    call avg3d (td2, avg_param)
-    if (nrank == 0) write(*,*)'## SUB momentum_rhs_eq VAR td2 (uu) AVG ', avg_param
+#ifdef DEBG
+    dep=maxval(abs(td2))
+    call MPI_ALLREDUCE(dep,dep1,1,real_type,MPI_MAX,MPI_COMM_WORLD,code)
+    if (nrank == 0) write(*,*)'## SUB momentum_rhs_eq VAR td2 (uu) MAX ', dep1
 #endif
 
     call dery (tg2,td2,di2,sy,ffy,fsy,fwy,ppy,ysize(1),ysize(2),ysize(3),0,ubcx*ubcy)
@@ -196,10 +194,10 @@ contains
     call dery (te2,uy2,di2,sy,ffy,fsy,fwy,ppy,ysize(1),ysize(2),ysize(3),0,ubcy)
     call dery (tf2,uz2,di2,sy,ffyp,fsyp,fwyp,ppy,ysize(1),ysize(2),ysize(3),1,ubcz)
 
-#ifdef DEBG 
-    avg_param = zero
-    call avg3d (td2, avg_param)
-    if (nrank == 0) write(*,*)'## SUB momentum_rhs_eq VAR td2 (du) AVG ', avg_param
+#ifdef DEBG
+    dep=maxval(abs(td2))
+    call MPI_ALLREDUCE(dep,dep1,1,real_type,MPI_MAX,MPI_COMM_WORLD,code)
+    if (nrank == 0) write(*,*)'## SUB momentum_rhs_eq VAR td2 (du) MAX ', dep1
 #endif
 
     ! Convective terms of y-pencil in tg2,th2,ti2
@@ -212,10 +210,10 @@ contains
       th2(:,:,:) = th2(:,:,:) + uy2(:,:,:) * te2(:,:,:)
       ti2(:,:,:) = ti2(:,:,:) + uy2(:,:,:) * tf2(:,:,:)
     endif
-#ifdef DEBG 
-    avg_param = zero
-    call avg3d (tg2, avg_param)
-    if (nrank == 0) write(*,*)'## SUB momentum_rhs_eq VAR tg2 (duu+udu) AVG ', avg_param
+#ifdef DEBG
+    dep=maxval(abs(tg2))
+    call MPI_ALLREDUCE(dep,dep1,1,real_type,MPI_MAX,MPI_COMM_WORLD,code)
+    if (nrank == 0) write(*,*)'## SUB momentum_rhs_eq VAR tg2 (duu+udu) MAX ', dep1
 #endif
 
 
@@ -245,9 +243,9 @@ contains
        tf3(:,:,:) = uz3(:,:,:) * uz3(:,:,:)
     endif
 #ifdef DEBG
-    avg_param = zero
-    call avg3d (td3, avg_param)
-    if (nrank == 0) write(*,*)'## SUB momentum_rhs_eq VAR td3 (uu) AVG ', avg_param
+    dep=maxval(abs(td3))
+    call MPI_ALLREDUCE(dep,dep1,1,real_type,MPI_MAX,MPI_COMM_WORLD,code)
+    if (nrank == 0) write(*,*)'## SUB momentum_rhs_eq VAR td3 (uu) MAX ', dep1
 #endif
 
     call derz (tg3,td3,di3,sz,ffz,fsz,fwz,zsize(1),zsize(2),zsize(3),0,ubcx*ubcz)
@@ -281,9 +279,9 @@ contains
        tc3(:,:,:) = tc3(:,:,:) + rho3(:,:,:) * uz3(:,:,:) * divu3(:,:,:)
     endif
 #ifdef DEBG
-    avg_param = zero
-    call avg3d (ta3, avg_param)
-    if (nrank == 0) write(*,*)'## SUB momentum_rhs_eq VAR ta3 (duu+udu) AVG ', avg_param
+    dep=maxval(abs(ta3))
+    call MPI_ALLREDUCE(dep,dep1,1,real_type,MPI_MAX,MPI_COMM_WORLD,code)
+    if (nrank == 0) write(*,*)'## SUB momentum_rhs_eq VAR ta3 (duu+udu) MAX ', dep1
 #endif
 
     ! Convective terms of z-pencil are in ta3 -> td3, tb3 -> te3, tc3 -> tf3
@@ -318,9 +316,9 @@ contains
     th2(:,:,:) = te2(:,:,:) - half * th2(:,:,:)
     ti2(:,:,:) = tf2(:,:,:) - half * ti2(:,:,:)
 #ifdef DEBG
-    avg_param = zero
-    call avg3d (tg2, avg_param)
-    if (nrank == 0) write(*,*)'## SUB momentum_rhs_eq VAR tg2 (Conv+Diff)) AVG ', avg_param
+    dep=maxval(abs(tg2))
+    call MPI_ALLREDUCE(dep,dep1,1,real_type,MPI_MAX,MPI_COMM_WORLD,code)
+    if (nrank == 0) write(*,*)'## SUB momentum_rhs_eq VAR tg2 (Conv+Diff)) MAX ', dep1
 #endif
 
 
@@ -404,15 +402,15 @@ contains
        endif
     endif
 #ifdef DEBG
-    avg_param = zero
-    call avg3d (td2, avg_param)
-    if (nrank == 0) write(*,*)'## SUB momentum_rhs_eq VAR td2 (Diff Y) AVG ', avg_param
-    avg_param = zero
-    call avg3d (te2, avg_param)
-    if (nrank == 0) write(*,*)'## SUB momentum_rhs_eq VAR te2 (Diff Y) AVG ', avg_param
-    avg_param = zero
-    call avg3d (tf2, avg_param)
-    if (nrank == 0) write(*,*)'## SUB momentum_rhs_eq VAR tf2 (Diff Y) AVG ', avg_param
+    dep=maxval(abs(td2))
+    call MPI_ALLREDUCE(dep,dep1,1,real_type,MPI_MAX,MPI_COMM_WORLD,code)
+    if (nrank == 0) write(*,*)'## SUB momentum_rhs_eq VAR td2 (Diff Y) MAX ', dep1
+    dep=maxval(abs(te2))
+    call MPI_ALLREDUCE(dep,dep1,1,real_type,MPI_MAX,MPI_COMM_WORLD,code)
+    if (nrank == 0) write(*,*)'## SUB momentum_rhs_eq VAR te2 (Diff Y) MAX ', dep1
+    dep=maxval(abs(tf2))
+    call MPI_ALLREDUCE(dep,dep1,1,real_type,MPI_MAX,MPI_COMM_WORLD,code)
+    if (nrank == 0) write(*,*)'## SUB momentum_rhs_eq VAR tf2 (Diff Y) MAX ', dep1
 #endif
 
 
@@ -447,15 +445,15 @@ contains
       tf1(:,:,:) = xnu * tf1(:,:,:)
     endif
 #ifdef DEBG
-    avg_param = zero
-    call avg3d (td1, avg_param)
-    if (nrank == 0) write(*,*)'## SUB momentum_rhs_eq VAR td1 (Diff X) AVG ', avg_param
-    avg_param = zero
-    call avg3d (te1, avg_param)
-    if (nrank == 0) write(*,*)'## SUB momentum_rhs_eq VAR te1 (Diff X) AVG ', avg_param
-    avg_param = zero
-    call avg3d (tf1, avg_param)
-    if (nrank == 0) write(*,*)'## SUB momentum_rhs_eq VAR tf1 (Diff X) AVG ', avg_param
+    dep=maxval(abs(td1))
+    call MPI_ALLREDUCE(dep,dep1,1,real_type,MPI_MAX,MPI_COMM_WORLD,code)
+    if (nrank == 0) write(*,*)'## SUB momentum_rhs_eq VAR td1 (Diff X) MAX ', dep1
+    dep=maxval(abs(te1))
+    call MPI_ALLREDUCE(dep,dep1,1,real_type,MPI_MAX,MPI_COMM_WORLD,code)
+    if (nrank == 0) write(*,*)'## SUB momentum_rhs_eq VAR te1 (Diff X) MAX ', dep1
+    dep=maxval(abs(tf1))
+    call MPI_ALLREDUCE(dep,dep1,1,real_type,MPI_MAX,MPI_COMM_WORLD,code)
+    if (nrank == 0) write(*,*)'## SUB momentum_rhs_eq VAR tf1 (Diff X) MAX ', dep1
 #endif
 
     !FINAL SUM: DIFF TERMS + CONV TERMS
@@ -463,29 +461,29 @@ contains
     duy1(:,:,:,1) = tb1(:,:,:) - half*th1(:,:,:)  + te1(:,:,:)
     duz1(:,:,:,1) = tc1(:,:,:) - half*ti1(:,:,:)  + tf1(:,:,:)
 #ifdef DEBG
-    avg_param = zero
-    call avg3d (dux1, avg_param)
-    if (nrank == 0) write(*,*)'## MomRHS dux1 ', avg_param
-    avg_param = zero
-    call avg3d (duy1, avg_param)
-    if (nrank == 0) write(*,*)'## MomRHS duy1 ', avg_param
-    avg_param = zero
-    call avg3d (duz1, avg_param)
-    if (nrank == 0) write(*,*)'## MomRHS duz1 ', avg_param
+    dep=maxval(abs(dux1))
+    call MPI_ALLREDUCE(dep,dep1,1,real_type,MPI_MAX,MPI_COMM_WORLD,code)
+    if (nrank == 0) write(*,*)'## MomRHS dux1 ', dep1
+    dep=maxval(abs(duy1))
+    call MPI_ALLREDUCE(dep,dep1,1,real_type,MPI_MAX,MPI_COMM_WORLD,code)
+    if (nrank == 0) write(*,*)'## MomRHS duy1 ', dep1
+    dep=maxval(abs(duz1))
+    call MPI_ALLREDUCE(dep,dep1,1,real_type,MPI_MAX,MPI_COMM_WORLD,code)
+    if (nrank == 0) write(*,*)'## MomRHS duz1 ', dep1
 #endif
     if (ilmn) then
        call momentum_full_viscstress_tensor(dux1(:,:,:,1), duy1(:,:,:,1), duz1(:,:,:,1), divu3, mu1)
     endif
 #ifdef DEBG
-    avg_param = zero
-    call avg3d (dux1, avg_param)
-    if (nrank == 0) write(*,*)'## MomRHS VisTau dux1 ', avg_param
-    avg_param = zero
-    call avg3d (duy1, avg_param)
-    if (nrank == 0) write(*,*)'## MomRHS VisTau duy1 ', avg_param
-    avg_param = zero
-    call avg3d (duz1, avg_param)
-    if (nrank == 0) write(*,*)'## MomRHS VisTau duz1 ', avg_param
+    dep=maxval(abs(dux1))
+    call MPI_ALLREDUCE(dep,dep1,1,real_type,MPI_MAX,MPI_COMM_WORLD,code)
+    if (nrank == 0) write(*,*)'## MomRHS VisTau dux1 ', dep1
+    dep=maxval(abs(duy1))
+    call MPI_ALLREDUCE(dep,dep1,1,real_type,MPI_MAX,MPI_COMM_WORLD,code)
+    if (nrank == 0) write(*,*)'## MomRHS VisTau duy1 ', dep1
+    dep=maxval(abs(duz1))
+    call MPI_ALLREDUCE(dep,dep1,1,real_type,MPI_MAX,MPI_COMM_WORLD,code)
+    if (nrank == 0) write(*,*)'## MomRHS VisTau duz1 ', dep1
 #endif
 
     ! If LES modelling is enabled, add the SGS stresses
@@ -502,15 +500,15 @@ contains
        duz1(:,:,:,1) = duz1(:,:,:,1) + sgsz1(:,:,:)
     endif
 #ifdef DEBG
-    avg_param = zero
-    call avg3d (dux1, avg_param)
-    if (nrank == 0) write(*,*)'## MomRHS LES dux1 ', avg_param
-    avg_param = zero
-    call avg3d (duy1, avg_param)
-    if (nrank == 0) write(*,*)'## MomRHS LES duy1 ', avg_param
-    avg_param = zero
-    call avg3d (duz1, avg_param)
-    if (nrank == 0) write(*,*)'## MomRHS LES duz1 ', avg_param
+    dep=maxval(abs(dux1))
+    call MPI_ALLREDUCE(dep,dep1,1,real_type,MPI_MAX,MPI_COMM_WORLD,code)
+    if (nrank == 0) write(*,*)'## MomRHS LES dux1 ', dep1
+    dep=maxval(abs(duy1))
+    call MPI_ALLREDUCE(dep,dep1,1,real_type,MPI_MAX,MPI_COMM_WORLD,code)
+    if (nrank == 0) write(*,*)'## MomRHS LES duy1 ', dep1
+    dep=maxval(abs(duz1))
+    call MPI_ALLREDUCE(dep,dep1,1,real_type,MPI_MAX,MPI_COMM_WORLD,code)
+    if (nrank == 0) write(*,*)'## MomRHS LES duz1 ', dep1
 #endif
 
     if (ilmn) then
@@ -525,28 +523,28 @@ contains
       enddo
     endif
 #ifdef DEBG
-    avg_param = zero
-    call avg3d (dux1, avg_param)
-    if (nrank == 0) write(*,*)'## MomRHS ILMN dux1 ', avg_param
-    avg_param = zero
-    call avg3d (duy1, avg_param)
-    if (nrank == 0) write(*,*)'## MomRHS ILMN duy1 ', avg_param
-    avg_param = zero
-    call avg3d (duz1, avg_param)
-    if (nrank == 0) write(*,*)'## MomRHS ILMN duz1 ', avg_param
+    dep=maxval(abs(dux1))
+    call MPI_ALLREDUCE(dep,dep1,1,real_type,MPI_MAX,MPI_COMM_WORLD,code)
+    if (nrank == 0) write(*,*)'## MomRHS ILMN dux1 ', dep1
+    dep=maxval(abs(duy1))
+    call MPI_ALLREDUCE(dep,dep1,1,real_type,MPI_MAX,MPI_COMM_WORLD,code)
+    if (nrank == 0) write(*,*)'## MomRHS ILMN duy1 ', dep1
+    dep=maxval(abs(duz1))
+    call MPI_ALLREDUCE(dep,dep1,1,real_type,MPI_MAX,MPI_COMM_WORLD,code)
+    if (nrank == 0) write(*,*)'## MomRHS ILMN duz1 ', dep1
 #endif
     !! Additional forcing
     call momentum_forcing(dux1, duy1, duz1, rho1, ux1, uy1, uz1, phi1)
 #ifdef DEBG
-    avg_param = zero
-    call avg3d (dux1, avg_param)
-    if (nrank == 0) write(*,*)'## MomRHS Forc dux1 ', avg_param
-    avg_param = zero
-    call avg3d (duy1, avg_param)
-    if (nrank == 0) write(*,*)'## MomRHS Forc duy1 ', avg_param
-    avg_param = zero
-    call avg3d (duz1, avg_param)
-    if (nrank == 0) write(*,*)'## MomRHS Forc duz1 ', avg_param
+    dep=maxval(abs(dux1))
+    call MPI_ALLREDUCE(dep,dep1,1,real_type,MPI_MAX,MPI_COMM_WORLD,code)
+    if (nrank == 0) write(*,*)'## MomRHS Forc dux1 ', dep1
+    dep=maxval(abs(duy1))
+    call MPI_ALLREDUCE(dep,dep1,1,real_type,MPI_MAX,MPI_COMM_WORLD,code)
+    if (nrank == 0) write(*,*)'## MomRHS Forc duy1 ', dep1
+    dep=maxval(abs(duz1))
+    call MPI_ALLREDUCE(dep,dep1,1,real_type,MPI_MAX,MPI_COMM_WORLD,code)
+    if (nrank == 0) write(*,*)'## MomRHS Forc duz1 ', dep1
 #endif
 
     !! Turbine forcing
@@ -560,15 +558,15 @@ contains
        duz1(:,:,:,1)=duz1(:,:,:,1)+Fdiscz(:,:,:)/rho_air
     endif
 #ifdef DEBG
-    avg_param = zero
-    call avg3d (dux1, avg_param)
-    if (nrank == 0) write(*,*)'## MomRHS Turb dux1 ', avg_param
-    avg_param = zero
-    call avg3d (duy1, avg_param)
-    if (nrank == 0) write(*,*)'## MomRHS Turb duy1 ', avg_param
-    avg_param = zero
-    call avg3d (duz1, avg_param)
-    if (nrank == 0) write(*,*)'## MomRHS Turb duz1 ', avg_param
+    dep=maxval(abs(dux1))
+    call MPI_ALLREDUCE(dep,dep1,1,real_type,MPI_MAX,MPI_COMM_WORLD,code)
+    if (nrank == 0) write(*,*)'## MomRHS Turb dux1 ', dep1
+    dep=maxval(abs(duy1))
+    call MPI_ALLREDUCE(dep,dep1,1,real_type,MPI_MAX,MPI_COMM_WORLD,code)
+    if (nrank == 0) write(*,*)'## MomRHS Turb duy1 ', dep1
+    dep=maxval(abs(duz1))
+    call MPI_ALLREDUCE(dep,dep1,1,real_type,MPI_MAX,MPI_COMM_WORLD,code)
+    if (nrank == 0) write(*,*)'## MomRHS Turb duz1 ', dep1
 #endif
 
     if (itrip == 1) then
@@ -577,15 +575,15 @@ contains
        if ((nrank==0).and.(mod(itime,ilist)==0)) write(*,*) 'TRIPPING!!'
     endif
 #ifdef DEBG
-    avg_param = zero
-    call avg3d (dux1, avg_param)
-    if (nrank == 0) write(*,*)'## MomRHS Trip dux1 ', avg_param
-    avg_param = zero
-    call avg3d (duy1, avg_param)
-    if (nrank == 0) write(*,*)'## MomRHS Trip duy1 ', avg_param
-    avg_param = zero
-    call avg3d (duz1, avg_param)
-    if (nrank == 0) write(*,*)'## MomRHS Trip duz1 ', avg_param
+    dep=maxval(abs(dux1))
+    call MPI_ALLREDUCE(dep,dep1,1,real_type,MPI_MAX,MPI_COMM_WORLD,code)
+    if (nrank == 0) write(*,*)'## MomRHS Trip dux1 ', dep1
+    dep=maxval(abs(duy1))
+    call MPI_ALLREDUCE(dep,dep1,1,real_type,MPI_MAX,MPI_COMM_WORLD,code)
+    if (nrank == 0) write(*,*)'## MomRHS Trip duy1 ', dep1
+    dep=maxval(abs(duz1))
+    call MPI_ALLREDUCE(dep,dep1,1,real_type,MPI_MAX,MPI_COMM_WORLD,code)
+    if (nrank == 0) write(*,*)'## MomRHS Trip duz1 ', dep1
 #endif
 
   end subroutine momentum_rhs_eq

--- a/src/xcompact3d.f90
+++ b/src/xcompact3d.f90
@@ -307,22 +307,24 @@ endsubroutine finalise_xcompact3d
 subroutine check_transients()
 
   use decomp_2d, only : mytype
-
+  use mpi
   use var
-  use tools, only : avg3d
   
   implicit none
 
-  real(mytype) avg_param
-  
-  avg_param = zero
-  call avg3d (dux1, avg_param)
-  if (nrank == 0) write(*,*)'## Main dux1 ', avg_param
-  avg_param = zero
-  call avg3d (duy1, avg_param)
-  if (nrank == 0) write(*,*)'## Main duy1 ', avg_param
-  avg_param = zero
-  call avg3d (duz1, avg_param)
-  if (nrank == 0) write(*,*)'## Main duz1 ', avg_param
+  real(mytype) :: dep, dep1
+  integer :: code
+   
+  dep=maxval(abs(dux1))
+  call MPI_ALLREDUCE(dep,dep1,1,real_type,MPI_MAX,MPI_COMM_WORLD,code)
+  if (nrank == 0) write(*,*)'## MAX dux1 ', dep1
+ 
+  dep=maxval(abs(duy1))
+  call MPI_ALLREDUCE(dep,dep1,1,real_type,MPI_MAX,MPI_COMM_WORLD,code)
+  if (nrank == 0) write(*,*)'## MAX duy1 ', dep1
+ 
+  dep=maxval(abs(duz1))
+  call MPI_ALLREDUCE(dep,dep1,1,real_type,MPI_MAX,MPI_COMM_WORLD,code)
+  if (nrank == 0) write(*,*)'## MAX duz1 ', dep1
   
 end subroutine check_transients


### PR DESCRIPTION
Removal of the avg3d subroutine which was used for debugging. Bugs were found when using the subroutine in Y and Z pencils and the averaging procedure was missing mesh nodes at the boundaries depending on the BC.

Instead, the maxval function is used, printing the max value of a 3D array (only in debugging mode). If NaN are present, they will clearly be identified.

The new code has been tested for the TGV, Cylinder and channel flow with gfortran 11.2 and Openmpi 4.1.0.

Few tests in the poisson.f90 have been removed, as not necessary anymore with maxval.