### PR TITLE
Add example of precursor ABL and successor ADM

### DIFF
--- a/examples/Wind-Turbine/precursor-succesor-ADM/precursor/input_neutral_precursor.i3d
+++ b/examples/Wind-Turbine/precursor-succesor-ADM/precursor/input_neutral_precursor.i3d
@@ -1,0 +1,151 @@
+! -*- mode: f90 -*-
+
+!===================
+&BasicParam
+!===================
+
+! Flow type (1=Lock-exchange, 2=TGV, 3=Channel, 4=Periodic hill, 5=Cylinder, 6=dbg-schemes, 9=Turbulent-Boundary-Layer, 10=ABL, 11=Uniform)
+itype=10
+
+! Domain decomposition
+p_row=0              ! Row partition
+p_col=0              ! Column partition
+! Obs.: For appropriate performance, the numbers ny/p_row and nz/p_col
+! (or (ny-1)/p_row and (nz-1)/p_col, if no periodic B.C. is used)
+! need to be integers, otherwise the FFT will be computed slowly
+
+! Mesh
+nx=64                ! X-direction nodes
+ny=43                ! Y-direction nodes
+nz=32                ! Z-direction nodes
+! Obs.: If no periodic boundary conditions is used, this numbers should be odd,
+! as one ghost layer is added in the numerical implementation
+
+istret = 0           ! y mesh refinement (0:no, 1:center, 2:both sides, 3:bottom)
+beta = 0.7           ! Refinement parameter (beta)
+
+! Domain
+xlx=1.44             ! Lx (Size of the box in x-direction)
+yly=0.46             ! Ly (Size of the box in y-direction)
+zlz=0.72             ! Lz (Size of the box in z-direction)
+
+! Boundary conditions
+nclx1 = 0 ! label '2' is for inflow/outflow B.C.
+nclxn = 0
+ncly1 = 2 ! label '1' is for slip B.C.
+nclyn = 1
+nclz1 = 0 ! label '0' is for periodic B.C.
+nclzn = 0
+
+! Flow parameters
+iin = 1              ! Inflow conditions (1: classic, 2: turbinit, 3:turbulence from file)
+re  = 66667.         ! nu=1/re (Kinematic Viscosity)
+u1  = 10.            ! u1 (max velocity) (for inflow condition)
+u2  = 10.            ! u2 (min velocity) (for inflow condition)
+init_noise = 0.5     ! Turbulence intensity (1=100%) !! Initial condition
+inflow_noise=0.1     ! Turbulence intensity (1=100%) !! Inflow condition
+
+! Time stepping
+dt = 0.0012          ! Time step
+ifirst = 1           ! First iteration
+ilast =  100000      ! Last iteration
+
+! Enable modelling tools
+ilesmod=1            ! if 0 then DNS (=1 before)
+numscalar = 0        ! How many scalars? (Set to zero to disable scalars)
+iibm=0               ! Flag for immersed boundary method
+iturbine=0           
+ifilter=1
+C_filter=0.49
+
+/End
+
+!====================
+&NumOptions
+!====================
+
+! Spatial derivatives
+ifirstder = 4        ! (1->2nd central, 2->4th central, 3->4th compact, 4-> 6th compact)
+isecondder = 4       ! (1->2nd central, 2->4th central, 3->4th compact, 4-> 6th compact, 5->hyperviscous 6th)
+ipinter = 1          ! interpolation scheme (1: classic, 2: optimized, 3: optimized agressive)
+
+! Time scheme
+itimescheme = 3      ! Time integration scheme (1->Euler,2->AB2, 3->AB3, 4->AB4,5->RK3,6->RK4, 7->Semi-implicit)
+
+! Dissipation control
+nu0nu = 3            ! Ratio between hyperviscosity/viscosity at nu
+cnu = 0.44           ! Ratio between hypervisvosity at k_m=2/3pi and k_c= pi
+
+/End
+
+!=================
+&InOutParam
+!=================
+
+! Basic I/O
+irestart = 0         ! Read initial flow field ?
+icheckpoint = 25000  ! Frequency for writing backup file
+ioutput = 25000      ! Frequency for visualization
+ilist =  100         ! Frequency for write to screen 
+nvisu = 1            ! Size for visualisation collection
+ioutflow=1           ! Outflow flag
+ntimesteps=25000     ! Number of planes saved in each file
+
+/End
+
+!=================
+&Statistics
+!=================
+
+wrotation = 0.12     ! rotation speed to trigger turbulence
+spinup_time = 0      ! number of time steps with a rotation to trigger turbulence
+nstat = 1            ! Size arrays for statistic collection
+initstat = 25001     ! Time steps after which statistics are collected 
+
+/End
+
+!########################
+! OPTIONAL PARAMETERS
+!#######################
+
+!================
+&LESModel
+!================
+
+jles = 1             ! LES Model (1: Phys Smag, 2: Phys WALE, 3: Phys dyn. Smag, 4: iSVV, 5: dyn SEV)
+smagcst = 0.14       ! Smagorinsky constant
+SmagWallDamp = 1     ! 1: Mason and Thomson Damping function, otherwise OFF
+nSmag = 3            ! Smag damping coeff (for use with M+T damping
+walecst = 0.5        ! WALES Model Coefficient
+iconserv = 1         ! Formulation SGS divergence (0: non conservative, 1: conservative)
+
+/End
+
+!================
+&ABL
+!================
+
+dsampling=1.5        ! Sampling velocity for the wall model at delta=dsampling*dy
+z_zero=0.00005       ! Roughness length
+k_roughness=0.4      ! von Karman constant (usually taken to be equal to 0.4)
+ustar=0.11           ! friction velocity
+dBL=0.46             ! Boundary layer height
+iPressureGradient=1  ! 0: Geostrophic Vel 1: PG forcing
+UG=0,0,0
+ibuoyancy=0          ! Buoyancy effects
+ishiftedper=1
+idamping=0           ! Damping zone
+istrat=1             ! 0: Stable BL 1: Convective BL
+itherm=0             ! 0: Surface flux 1: Surface temperature
+icoriolis=0          ! Coriolis forces
+coriolisfreq=1e-04
+iheight=0            ! Compute BL height
+imassconserve=0      ! Enforce mass conservation
+T_wall=300.          ! Initial wall temperature
+T_top=310.814        ! Temperature at domain top
+
+/End
+
+&CASE
+/End
+

--- a/examples/Wind-Turbine/precursor-succesor-ADM/succesor_ADM/adm.ad
+++ b/examples/Wind-Turbine/precursor-succesor-ADM/succesor_ADM/adm.ad
@@ -1,0 +1,2 @@
+!CoR(x) CoR(y) CoR(z) YawAng[deg] TiltAng[deg] RotorDiam C_T[-] alpha[-]
+0.9 0.125 0.36 0 0 0.15 0.556 0.17095

--- a/examples/Wind-Turbine/precursor-succesor-ADM/succesor_ADM/input.i3d
+++ b/examples/Wind-Turbine/precursor-succesor-ADM/succesor_ADM/input.i3d
@@ -1,0 +1,162 @@
+! -*- mode: f90 -*-
+
+!===================
+&BasicParam
+!===================
+
+! Flow type (1=Lock-exchange, 2=TGV, 3=Channel, 4=Periodic hill, 5=Cylinder, 6=dbg-schemes, 9=Turbulent-Boundary-Layer, 10=ABL, 11=Uniform)
+itype=10
+
+! Domain decomposition
+p_row=0              ! Row partition
+p_col=0              ! Column partition
+! Obs.: For appropriate performance, the numbers ny/p_row and nz/p_col
+! (or (ny-1)/p_row and (nz-1)/p_col, if no periodic B.C. is used)
+! need to be integers, otherwise the FFT will be computed slowly
+! Mesh
+nx=193               ! X-direction nodes
+ny=43                ! Y-direction nodes
+nz=32                ! Z-direction nodes
+! Obs.: If no periodic boundary conditions is used, this numbers should be odd,
+! as one ghost layer is added in the numerical implementation
+istret = 0           ! y mesh refinement (0:no, 1:center, 2:both sides, 3:bottom)
+beta = 0.7           ! Refinement parameter (beta)
+
+! Domain
+xlx=4.32             ! Lx (Size of the box in x-direction)
+yly=0.46             ! Ly (Size of the box in y-direction)
+zlz=0.72             ! Lz (Size of the box in z-direction)
+
+! Boundary conditions
+nclx1 = 2 ! label '2' is for inflow/outflow B.C.
+nclxn = 2
+ncly1 = 2 ! label '1' is for slip B.C.
+nclyn = 1
+nclz1 = 0 ! label '0' is for periodic B.C.
+nclzn = 0
+
+! Flow parameters
+iin = 3              ! Inflow conditions (1: classic, 2: turbinit, 3:turbulence from file)
+re  = 66667.         ! nu=1/re (Kinematic Viscosity)
+u1  = 10.            ! u1 (max velocity) (for inflow condition)
+u2  = 10.            ! u2 (min velocity) (for inflow condition)
+init_noise = 0.5     ! Turbulence intensity (1=100%) !! Initial condition
+inflow_noise=0.1     ! Turbulence intensity (1=100%) !! Inflow condition
+
+! Time stepping
+dt = 0.0012          ! Time step
+ifirst = 1           ! First iteration
+ilast =  100000      ! Last iteration
+
+! Enable modelling tools
+ilesmod=1            ! if 0 then DNS (=1 before)
+numscalar = 0        ! How many scalars? (Set to zero to disable scalars)
+iibm=0               ! Flag for immersed boundary method
+iturbine=2           
+ifilter=1
+C_filter=0.49
+
+/End
+
+!====================
+&NumOptions
+!====================
+
+! Spatial derivatives
+ifirstder = 4        ! (1->2nd central, 2->4th central, 3->4th compact, 4-> 6th compact)
+isecondder = 4       ! (1->2nd central, 2->4th central, 3->4th compact, 4-> 6th compact, 5->hyperviscous 6th)
+ipinter = 1          ! interpolation scheme (1: classic, 2: optimized, 3: optimized agressive)
+
+! Time scheme
+itimescheme = 3      ! Time integration scheme (1->Euler,2->AB2, 3->AB3, 4->AB4,5->RK3,6->RK4, 7->Semi-implicit)
+
+! Dissipation control
+nu0nu = 3            ! Ratio between hyperviscosity/viscosity at nu
+cnu = 0.44           ! Ratio between hypervisvosity at k_m=2/3pi and k_c= pi
+
+/End
+
+!=================
+&InOutParam
+!=================
+
+! Basic I/O
+irestart = 0         ! Read initial flow field ?
+icheckpoint =  25000 ! Frequency for writing backup file
+ioutput =  25000     ! Frequency for visualization
+ilist =  100         ! Frequency for write to screen 
+nvisu = 1            ! Size for visualisation collection
+ioutflow=0           ! Outflow flag
+ntimesteps=25000     ! Number of planes saved in each file
+ninflows=3           ! Number of files storing inflow planes 
+inflowpath='../precursor/out/' ! Directory with the inflow files
+
+/End
+
+!=================
+&Statistics
+!=================
+
+wrotation = 0.12     ! rotation speed to trigger turbulence
+spinup_time = 0      ! number of time steps with a rotation to trigger turbulence
+nstat = 1            ! Size arrays for statistic collection
+initstat =  25001    ! Time steps after which statistics are collected 
+
+/End
+
+!########################
+! OPTIONAL PARAMETERS
+!#######################
+
+!================
+&LESModel
+!================
+
+jles = 1             ! LES Model (1: Phys Smag, 2: Phys WALE, 3: Phys dyn. Smag, 4: iSVV, 5: dyn SEV)
+smagcst = 0.14       ! Smagorinsky constant
+SmagWallDamp = 1     ! 1: Mason and Thomson Damping function, otherwise OFF
+nSmag = 3            ! Smag damping coeff (for use with M+T damping
+walecst = 0.5        ! WALES Model Coefficient
+iconserv = 1         ! Formulation SGS divergence (0: non conservative, 1: conservative)
+
+/End
+
+!================
+&ABL
+!================
+
+dsampling=1.5        ! Sampling velocity for the wall model at delta=dsampling*dy
+z_zero=0.00005       ! Roughness length
+k_roughness=0.4      ! von Karman constant (usually taken to be equal to 0.4)
+ustar=0.11           ! friction velocity
+dBL=0.46             ! Boundary layer height
+iPressureGradient=0  ! 0: Geostrophic Vel 1: PG forcing
+UG=0,0,0
+ibuoyancy=0          ! Buoyancy effects
+idamping=0           ! Damping zone
+istrat=1             ! 0: Stable BL 1: Convective BL
+itherm=0             ! 0: Surface flux 1: Surface temperature
+icoriolis=0          ! Coriolis forces
+coriolisfreq=1e-04
+iheight=0            ! Compute BL height
+imassconserve=0      ! Enforce mass conservation
+T_wall=300.          ! Initial wall temperature
+T_top=310.814        ! Temperature at domain top
+
+/End
+
+!================
+&ADMParam
+!================
+
+Ndiscs=1
+ADMcoords='adm.ad'
+iturboutput=250
+rho_air=1.2
+T_relax = 1.1291
+
+/End
+
+&CASE
+/End
+

--- a/src/BC-ABL.f90
+++ b/src/BC-ABL.f90
@@ -819,7 +819,7 @@ contains
     
     if (mod(itime,ilist)==0.and.nrank==0) then
        ! Write u_shear in file
-       write(42,'(20e20.12)') (itime-1)*dt,u_shear
+       write(42,'(20e20.12)') t,u_shear
        call flush(42)
        ! Print in terminal
        write(*,*)  ' ABL:'


### PR DESCRIPTION
Run first the precursor simulation to generate the turbulence and save planes to use as inlet for successor simulation. The inflow planes are saved in the out/ directory. Once the simulation has finished, change the names of the inflow files such that the _inflow1_ file corresponds to the first plane you want to use (skip the transient period). For example, one can use: `for i in {2..4}; do mv inflow$i inflow$((i-1)); done`, if the _inflow2_ file is storing the planes after the transient period and the last inflow file in _inflow4_.

The successor simulation input file includes the path to find the inflow planes and will use them to simulate an actuator disc with inlet atmospheric turbulence.

This case setup is presented in Stevens et al. (2018) [1](https://www.sciencedirect.com/science/article/pii/S0960148117308339)

[1] Stevens, R.J.A.M., Martínez-Tossas, L.A., Meneveau, C., 2018. Comparison of wind farm large eddy simulations using actuator disk and actuator line models with wind tunnel experiments. Renew. Energy 116, 470–478.