### PR TITLE
Error for stretching + periodicity

### DIFF
--- a/src/parameters.f90
+++ b/src/parameters.f90
@@ -231,6 +231,7 @@ subroutine parameter(input_i3d)
   if (ncly1.eq.0.and.nclyn.eq.0) then
      ncly=.true.
      nym=ny
+     if (istret.ne.0) call decomp_2d_abort(istret, "Invalid options (stretching + periodicity)")
   else
      ncly=.false.
      nym=ny-1


### PR DESCRIPTION
Print an error message and abort the simulation for invalid options