### PR TITLE
Correct typo in parameters.f90

### DIFF
--- a/src/parameters.f90
+++ b/src/parameters.f90
@@ -407,7 +407,7 @@ subroutine parameter(input_i3d)
        endif
      endif
      !
-     if (ilesmod.ne.0) then
+     if (ilesmod == 0) then ! Non-zero enables LES
        write(*,*) '                   : DNS'
      else
        if (jles==1) then


### PR DESCRIPTION
Typo shouldn't have affected code, simply won't report DNS when it should.