### PR TITLE
Add BC-Pipe-flow.f90 to src/CMakeLists.txt to fix compilation error

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -23,6 +23,7 @@ add_executable(xcompact3d
                     BC-Lock-exchange.f90
                     BC-Mixing-layer.f90
                     BC-Periodic-hill.f90
+                    BC-Pipe-flow.f90
 		    BC-Sandbox.f90
                     BC-TBL.f90
                     BC-TGV.f90


### PR DESCRIPTION
Compilation of the master branch (commit https://github.com/xcompact3d/Incompact3d/commit/34d69d2170bc172faafbdf80f697298ad9e89d0a) results in a compilation error. This error is caused be the fact that `BC-Pipe-flow.f90` was not included in the src/CMakeLists.txt file (probably just forgotten during last commit). Adding `BC-Pipe-flow.f90` to the CMakeLists.txt file fix the problem.