### PR TITLE
Fix examples/Sphere/generate_initial_conditions.py

### DIFF
--- a/examples/Sphere/generate_initial_conditions.py
+++ b/examples/Sphere/generate_initial_conditions.py
@@ -14,12 +14,12 @@ epsi = x3d.init_epsi(prm, dask=True)
 # Read the STL file
 for key in epsi.keys():
     print(key)
-    epsi[key] = epsi[key].geo.from_stl("sphere.stl",
+    epsi[key] = epsi[key].geo.from_stl(filename="sphere.stl",
                                        origin=dict(x=2.0,y=2.0,z=2.0), # locates the sphere centre at (2.5, 2.5, 2.5)
                                        scale=1.0/200.0, # Sphere has a diameter of 200, so rescale to a diameter of 1
                                        # rotate=dict(axis=[0,0,1],theta=math.radians(270)), # rotate the geometry
                                        user_tol=1e-3)
-dataset = x3d.gene_epsi_3D(epsi, prm)
+dataset = x3d.gene_epsi_3d(epsi, prm)
 
 if prm.iibm >= 2:
     prm.nobjmax = dataset.obj.size


### PR DESCRIPTION
The python script in examples/Sphere/generate_initial_conditions.py is broken. 

First the `from_stl` function should only accept keyword argument. Providing the filename as a positional argument cause the following error:

```
epsi
Traceback (most recent call last):
  File "generate_initial_conditions.py", line 17, in <module>
    epsi[key] = epsi[key].geo.from_stl("sphere.stl",
TypeError: from_stl() takes 1 positional argument but 2 positional arguments (and 3 keyword-only arguments) were given
```

A lower case `d` should be use in `gene_epsi_3D`. The current script produce the following error:

```
Traceback (most recent call last):
  File "generate_initial_conditions.py", line 22, in <module>
    dataset = x3d.gene_epsi_3D(epsi, prm)
AttributeError: module 'xcompact3d_toolbox' has no attribute 'gene_epsi_3D'

```
This PR fix this issue.