### PR TITLE
Fix intel

### DIFF
--- a/examples/MHD/input_mhdchan_test.i3d
+++ b/examples/MHD/input_mhdchan_test.i3d
@@ -12,7 +12,7 @@ p_row=0               ! Row partition
 p_col=0               ! Column partition
 
 ! Mesh
-nx=8                  ! X-direction nodes
+nx=16                  ! X-direction nodes
 ny=129                ! Y-direction nodes
 nz=1                  ! Z-direction nodes
 istret = 2            ! y mesh refinement (0:no, 1:center, 2:both sides, 3:bottom)

--- a/src/forces.f90
+++ b/src/forces.f90
@@ -121,13 +121,13 @@ contains
        elseif (i2dsim==0) then
          write(*,*) '========================Forces============================='
          write(*,*) '     (icvlf)      (icvrt)    (kcvbk)    (kcvfr)'
-         write(*,*) '  (jcvup) B____________C     B`_____________B'
-         write(*,*) '          |            |  |  |              |'
-         write(*,*) '          |     __     |  |  |     ____     |'
-         write(*,*) '          |    \__\    |  |  |     \___\    |'
-         write(*,*) '          |            |  |  |              |'
-         write(*,*) '          |       CV   |  |  |    (Front)   |'
-         write(*,*) '  (jcvlw) A____________D  |  A`_____________A'
+         write(*,*) '  (jcvup) B____________C     B`_____________B  '
+         write(*,*) '          \            \  |  \              \  '
+         write(*,*) '          \     __     \  |  \     ____     \  '
+         write(*,*) '          \    \__\    \  |  \     \___\    \  '
+         write(*,*) '          \            \  |  \              \  '
+         write(*,*) '          \       CV   \  |  \    (Front)   \  '
+         write(*,*) '  (jcvlw) A____________D  |  A`_____________A  '
          do iv=1,nvol
             write(*,"(' Control Volume     : #',I1)") iv
             write(*,"('     xld, icvlf     : (',F6.2,',',I6,')')") xld(iv), icvlf(iv)
@@ -244,6 +244,7 @@ contains
 
     use var, only : ta1, tb1, tc1, td1, te1, di1, tg1, tg2, tg3, th1, th2, th3, tf2, tf1
     use var, only : ux2, ux3, uy2, uy3, uz2, ta2, tb2, td2, te2, di2, di3
+    use var, only : tc2
 
     implicit none
     character(len=30) :: filename, filename2
@@ -255,7 +256,7 @@ contains
     real(mytype), dimension(xsize(1),xsize(2),xsize(3)),intent(in) :: ux1, uy1, uz1
     real(mytype), dimension(xsize(1),xsize(2),xsize(3)),intent(in) :: ep1
 
-    real(mytype), dimension(ysize(1),ysize(2),ysize(3)) :: ppi2
+    !real(mytype), dimension(ysize(1),ysize(2),ysize(3)) :: ppi2 ! we'll use tc2
 
     real(mytype), dimension(nz) :: yLift,xDrag
     real(mytype) :: yLift_mean,xDrag_mean
@@ -315,7 +316,7 @@ contains
 
     call transpose_x_to_y(ux1,ux2)
     call transpose_x_to_y(uy1,uy2)
-    call transpose_x_to_y(ppi1,ppi2)
+    call transpose_x_to_y(ppi1,tc2)
 
     call dery (td2,ux2,di2,sy,ffyp,fsyp,fwyp,ppy,ysize(1),ysize(2),ysize(3),1,ubcx) ! dudy
     call dery (te2,uy2,di2,sy,ffy,fsy,fwy,ppy,ysize(1),ysize(2),ysize(3),0,ubcy)    ! dvdy
@@ -506,7 +507,7 @@ contains
                   fcvy= fcvy -uxmid*uymid*del_y(j)
 
                   !pressure
-                  prmid=half*(ppi2(i,j,k)+ppi2(i,j+1,k))
+                  prmid=half*(tc2(i,j,k)+tc2(i,j+1,k))
                   fprx = fprx +prmid*del_y(j)
 
                   !viscous term
@@ -542,7 +543,7 @@ contains
                   fcvy= fcvy +uxmid*uymid*del_y(j)
 
                   !pressure
-                  prmid=half*(ppi2(i,j,k)+ppi2(i,j+1,k))
+                  prmid=half*(tc2(i,j,k)+tc2(i,j+1,k))
                   fprx = fprx -prmid*del_y(j)
 
                   !viscous term
@@ -680,7 +681,7 @@ contains
                    fcvy = fcvy + uxmid*uymid*del_y(j)*dz
  
                    !pressure
-                   prmid=half*(ppi2(i,j,k)+ppi2(i,j+1,k))
+                   prmid=half*(tc2(i,j,k)+tc2(i,j+1,k))
                    fprx = fprx -prmid*del_y(j)*dz
  
                    !viscous term
@@ -716,7 +717,7 @@ contains
                    fcvy = fcvy - uxmid*uymid*del_y(j)*dz
  
                    !pressure
-                   prmid=half*(ppi2(i,j,k)+ppi2(i,j+1,k))
+                   prmid=half*(tc2(i,j,k)+tc2(i,j+1,k))
                    fprx = fprx + prmid*del_y(j)*dz
  
                    !viscous term

--- a/src/les_models.f90
+++ b/src/les_models.f90
@@ -106,7 +106,8 @@ contains
     USE variables
     USE decomp_2d_io
     use var, only: nut1
-    !USE abl, only: wall_sgs_slip, wall_sgs_noslip
+    use var, only: ta1, tb1, tc1
+    use abl, only: wall_sgs_slip, wall_sgs_noslip
     implicit none
 
     real(mytype), dimension(xsize(1), xsize(2), xsize(3)), intent(in) :: ux1, uy1, uz1, ep1
@@ -115,7 +116,6 @@ contains
     !real(mytype), dimension(xsize(1), xsize(2), xsize(3)) :: w_fluxx1, w_fluxy1, w_fluxz1
     !real(mytype), dimension(xsize(1), xsize(2), xsize(3)) :: w_sgsx1, w_sgsy1, w_gsz1
 
-    write(*,*) "START Compute_SGS"
     ! Calculate eddy-viscosity
     if(jles.eq.1) then ! Smagorinsky
        call smag(nut1,ux1,uy1,uz1)
@@ -128,38 +128,36 @@ contains
 
     endif
 
-    !if(iconserv.eq.0) then ! Non-conservative form for calculating the divergence of the SGS stresses
-    !   call sgs_mom_nonconservative(sgsx1,sgsy1,sgsz1,ux1,uy1,uz1,nut1,ep1)
+    ! we can store wallflux in ta1, tb1, tc1
+    ! this will be done in all call to wall_sgs_ for the ABL
+    if(iconserv.eq.0) then ! Non-conservative form for calculating the divergence of the SGS stresses
+       call sgs_mom_nonconservative(sgsx1,sgsy1,sgsz1,ux1,uy1,uz1,nut1,ep1)
 
-    !   ! SGS correction for ABL
-    !   if(itype.eq.itype_abl) then
-    !      ! No-slip wall
-    !      if (ncly1==2) then 
-    !         call wall_sgs_noslip(ux1,uy1,uz1,nut1,wallfluxx1,wallfluxy1,wallfluxz1)
-    !         if(xstart(2)==1) then
-    !           sgsx1(:,2,:) = -wallfluxx1(:,2,:)
-    !           sgsy1(:,2,:) = -wallfluxy1(:,2,:)
-    !           sgsz1(:,2,:) = -wallfluxz1(:,2,:)
-    !         endif
-    !      ! Slip wall
-    !      elseif (ncly1==1) then
-    !         call wall_sgs_slip(ux1,uy1,uz1,phi1,nut1,wallfluxx1,wallfluxy1,wallfluxz1)
-    !         if(xstart(2)==1) then
-    !            sgsx1(:,1,:) = wallfluxx1(:,1,:)
-    !            sgsy1(:,1,:) = wallfluxy1(:,1,:)
-    !            sgsz1(:,1,:) = wallfluxz1(:,1,:)
-    !         endif
-    !      endif
-    !   endif
+       ! SGS correction for ABL
+       if(itype.eq.itype_abl) then
+          ! No-slip wall
+          if (ncly1==2) then 
+             call wall_sgs_noslip(ux1,uy1,uz1,nut1,ta1,tb1,tc1)
+             if(xstart(2)==1) then
+               sgsx1(:,2,:) = -ta1(:,2,:)
+               sgsy1(:,2,:) = -tb1(:,2,:)
+               sgsz1(:,2,:) = -tc1(:,2,:)
+             endif
+          ! Slip wall
+          elseif (ncly1==1) then
+             call wall_sgs_slip(ux1,uy1,uz1,phi1,nut1,ta1,tb1,tc1)
+             if(xstart(2)==1) then
+                sgsx1(:,1,:) = ta1(:,1,:)
+                sgsy1(:,1,:) = tb1(:,1,:)
+                sgsz1(:,1,:) = tc1(:,1,:)
+             endif
+          endif
+       endif
 
-    !elseif (iconserv.eq.1) then ! Conservative form for calculating the divergence of the SGS stresses (used with wall functions)
-    !   call sgs_mom_conservative(sgsx1,sgsy1,sgsz1,ux1,uy1,uz1,nut1)
+    elseif (iconserv.eq.1) then ! Conservative form for calculating the divergence of the SGS stresses (used with wall functions)
+       call sgs_mom_conservative(sgsx1,sgsy1,sgsz1,ux1,uy1,uz1,nut1)
 
-    !endif
-    sgsx1 = zero
-    sgsy1 = zero
-    sgsz1 = zero
-    write(*,*) "END Compute_SGS"
+    endif
 
     return
 
@@ -1112,15 +1110,15 @@ end subroutine wale
     
     implicit none
 
-    real(mytype), dimension(xsize(1), xsize(2), xsize(3)) :: ux1, uy1, uz1, nut1, ep1
-    real(mytype), dimension(xsize(1), xsize(2), xsize(3)) :: sgsx1, sgsy1, sgsz1
+    real(mytype), dimension(xsize(1), xsize(2), xsize(3)),intent(in) :: ux1, uy1, uz1, nut1, ep1
+    real(mytype), dimension(xsize(1), xsize(2), xsize(3)),intent(out):: sgsx1, sgsy1, sgsz1
 
     integer :: i, j, k, ijk, nvect1
 
     ta1 = zero; ta2 = zero; ta3 = zero
-    sgsx1=zero;sgsy1=zero;sgsz1=zero
-    sgsx2=zero;sgsy2=zero;sgsz2=zero
-    sgsx3=zero;sgsy3=zero;sgsz3=zero
+    sgsx1=zero; sgsy1=zero; sgsz1=zero
+    sgsx2=zero; sgsy2=zero; sgsz2=zero
+    sgsx3=zero; sgsy3=zero; sgsz3=zero
     !WORK X-PENCILS
     call derx (ta1,nut1,di1,sx,ffxp,fsxp,fwxp,xsize(1),xsize(2),xsize(3),1,zero)
 
@@ -1330,8 +1328,11 @@ end subroutine wale
     USE variables
     use MPI
     USE var, only : ta1,tb1,tc1,di1
+    use var, only : td1, te1, tf1, tg1, th1, ti1
     USE var, only : ta2,tb2,tc2,di2
+    use var, only :      te2, tf2, tg2, th2, ti2
     USE var, only : ta3,tb3,tc3,di3
+    use var, only :           tf3,      th3, ti3
     USE var, only : sgsx2,sgsy2,sgsz2
     USE var, only : sgsx3,sgsy3,sgsz3
     USE var, only : sxx1,sxy1,sxz1,syy1,syz1,szz1
@@ -1340,37 +1341,36 @@ end subroutine wale
     
     implicit none 
 
-    real(mytype), dimension(xsize(1), xsize(2), xsize(3)) :: ux1, uy1, uz1, nut1
-    real(mytype), dimension(xsize(1), xsize(2), xsize(3)) :: sgsx1, sgsy1, sgsz1
-    real(mytype), dimension(xsize(1), xsize(2), xsize(3)) :: wallsgsx1, wallsgsy1, wallsgsz1
-    real(mytype), dimension(xsize(1), xsize(2), xsize(3)) :: txx1, txy1, txz1, tyy1, tyz1, tzz1 
-    real(mytype), dimension(xsize(1), xsize(2), xsize(3)) :: taf1, tbf1, tcf1
-    real(mytype), dimension(ysize(1), ysize(2), ysize(3)) :: txy2, txz2, tyy2, tyz2, tzz2 
-    real(mytype), dimension(ysize(1), ysize(2), ysize(3)) :: taf2, tbf2, tcf2
-    real(mytype), dimension(zsize(1), zsize(2), zsize(3)) :: txz3, tyz3, tzz3 
-    real(mytype), dimension(zsize(1), zsize(2), zsize(3)) :: taf3, tbf3, tcf3 
+    real(mytype), dimension(xsize(1), xsize(2), xsize(3)),intent(in) :: ux1, uy1, uz1, nut1
+    real(mytype), dimension(xsize(1), xsize(2), xsize(3)),intent(out) :: sgsx1, sgsy1, sgsz1
 
+    !                                                         ta1        tb1        tc1 
+    !real(mytype), dimension(xsize(1), xsize(2), xsize(3)) :: wallsgsx1, wallsgsy1, wallsgsz1
+    !
+    !                                                         td1  te1  tf1  tg1  th1  ti1         
+    !real(mytype), dimension(xsize(1), xsize(2), xsize(3)) :: txx, txy, txz, tyy, tyz, tzz 
+    
     integer :: i, j, k, code, ierr
     
     ! Construct stress tensor
-    txx1 = 2.0*nut1*sxx1
-    txy1 = 2.0*nut1*sxy1
-    txz1 = 2.0*nut1*sxz1
-    tyy1 = 2.0*nut1*syy1
-    tyz1 = 2.0*nut1*syz1
-    tzz1 = 2.0*nut1*szz1   
+    td1 = 2.0*nut1*sxx1
+    te1 = 2.0*nut1*sxy1
+    tf1 = 2.0*nut1*sxz1
+    tg1 = 2.0*nut1*syy1
+    th1 = 2.0*nut1*syz1
+    ti1 = 2.0*nut1*szz1   
     
     ! Add wall model for ABL
     if (itype.eq.itype_abl) then
       if (ncly1==2) then 
-        call wall_sgs_noslip(ux1,uy1,uz1,nut1,wallsgsx1,wallsgsy1,wallsgsz1)
+        call wall_sgs_noslip(ux1,uy1,uz1,nut1,ta1,tb1,tc1)
         if (xstart(2)==1) then
-          txx1(:,2,:) = 0.
-          txy1(:,2,:) = - wallsgsx1(:,2,:)! txy1(:,2,:)
-          txz1(:,2,:) = 0.
-          tyy1(:,2,:) = 0.
-          tyz1(:,2,:) = - wallsgsz1(:,2,:)! tyz1(:,2,:)
-          tzz1(:,2,:) = 0.
+          td1(:,2,:) = 0.
+          te1(:,2,:) = - ta1(:,2,:)! txy1(:,2,:)
+          tf1(:,2,:) = 0.
+          tg1(:,2,:) = 0.
+          th1(:,2,:) = - tc1(:,2,:)! tyz1(:,2,:)
+          ti1(:,2,:) = 0.
         endif
       elseif (ncly1==1) then 
         write(*,*) 'Simulation stopped: slip bottom wall not supported with iconserv=1'
@@ -1382,37 +1382,38 @@ end subroutine wale
     ta1 = zero; ta2 = zero; ta3 = zero
     tb1 = zero; tb2 = zero; tb3 = zero
     tc1 = zero; tc2 = zero; tc3 = zero
-    sgsx1=0.;sgsy1=0.;sgsz1=0.
-    sgsx2=0.;sgsy2=0.;sgsz2=0.
-    sgsx3=0.;sgsy3=0.;sgsz3=0.
+    sgsx1=zero; sgsy1=zero; sgsz1=zero
+    sgsx2=zero; sgsy2=zero; sgsz2=zero
+    sgsx3=zero; sgsy3=zero; sgsz3=zero
 
     ! WORK X-PENCILS
-    call derx (ta1,txx1,di1,sx,ffx,fsx,fwx,xsize(1),xsize(2),xsize(3),0,zero)
-    call derx (tb1,txy1,di1,sx,ffx,fsx,fwx,xsize(1),xsize(2),xsize(3),0,zero)
-    call derx (tc1,txz1,di1,sx,ffx,fsx,fwx,xsize(1),xsize(2),xsize(3),0,zero)
+    call derx (sgsx1,td1,di1,sx,ffx,fsx,fwx,xsize(1),xsize(2),xsize(3),0,zero)
+    call derx (sgsy1,te1,di1,sx,ffx,fsx,fwx,xsize(1),xsize(2),xsize(3),0,zero)
+    call derx (sgsz1,tf1,di1,sx,ffx,fsx,fwx,xsize(1),xsize(2),xsize(3),0,zero)
 
     !call filter(0.48d0)
     !call filx(taf1,ta1,di1,fisx,fiffxp,fifsxp,fifwxp,xsize(1),xsize(2),xsize(3),1,zero)
     !call filx(tbf1,tb1,di1,fisx,fiffxp,fifsxp,fifwxp,xsize(1),xsize(2),xsize(3),1,zero)
     !call filx(tcf1,tc1,di1,fisx,fiffxp,fifsxp,fifwxp,xsize(1),xsize(2),xsize(3),1,zero)
 
-    sgsx1 = ta1
-    sgsy1 = tb1
-    sgsz1 = tc1
+    ! Stored into var immediatly not here
+    !sgsx1 = ta1
+    !sgsy1 = tb1
+    !sgsz1 = tc1
 
     ! WORK Y-PENCILS
-    call transpose_x_to_y(txy1, txy2)
-    call transpose_x_to_y(tyy1, tyy2)
-    call transpose_x_to_y(tyz1, tyz2)
-    call transpose_x_to_y(txz1, txz2)
-    call transpose_x_to_y(tzz1, tzz2)
+    call transpose_x_to_y(te1, te2)
+    call transpose_x_to_y(tg1, tg2)
+    call transpose_x_to_y(th1, th2)
+    call transpose_x_to_y(tf1, tf2)
+    call transpose_x_to_y(ti1, ti2)
     call transpose_x_to_y(sgsx1, sgsx2)
     call transpose_x_to_y(sgsy1, sgsy2)
     call transpose_x_to_y(sgsz1, sgsz2)
 
-    call dery (ta2,txy2,di2,sy,ffy,fsy,fwy,ppy,ysize(1),ysize(2),ysize(3),0,zero)
-    call dery (tb2,tyy2,di2,sy,ffyp,fsyp,fwyp,ppy,ysize(1),ysize(2),ysize(3),1,zero)
-    call dery (tc2,tyz2,di2,sy,ffy,fsy,fwy,ppy,ysize(1),ysize(2),ysize(3),0,zero)
+    call dery (ta2,te2,di2,sy,ffy,fsy,fwy,ppy,ysize(1),ysize(2),ysize(3),0,zero)
+    call dery (tb2,tg2,di2,sy,ffyp,fsyp,fwyp,ppy,ysize(1),ysize(2),ysize(3),1,zero)
+    call dery (tc2,th2,di2,sy,ffy,fsy,fwy,ppy,ysize(1),ysize(2),ysize(3),0,zero)
 
     !call fily(taf2,ta2,di2,fisy,fiffyp,fifsyp,fifwyp,ysize(1),ysize(2),ysize(3),1,zero)
     !call fily(tbf2,tb2,di2,fisy,fiffyp,fifsyp,fifwyp,ysize(1),ysize(2),ysize(3),1,zero)
@@ -1426,13 +1427,13 @@ end subroutine wale
     call transpose_y_to_z(sgsx2, sgsx3)
     call transpose_y_to_z(sgsy2, sgsy3)
     call transpose_y_to_z(sgsz2, sgsz3)
-    call transpose_y_to_z(txz2, txz3)
-    call transpose_y_to_z(tyz2, tyz3)
-    call transpose_y_to_z(tzz2, tzz3)
+    call transpose_y_to_z(tf2, tf3)
+    call transpose_y_to_z(th2, th3)
+    call transpose_y_to_z(ti2, ti3)
 
-    call derz (ta3, txz3, di3, sz, ffz, fsz, fwz, zsize(1), zsize(2), zsize(3), 0, zero)
-    call derz (tb3, tyz3, di3, sz, ffz, fsz, fwz, zsize(1), zsize(2), zsize(3), 0, zero)
-    call derz (tc3, tzz3, di3, sz, ffz, fsz, fwz, zsize(1), zsize(2), zsize(3), 0, zero)
+    call derz (ta3, tf3, di3, sz, ffz, fsz, fwz, zsize(1), zsize(2), zsize(3), 0, zero)
+    call derz (tb3, th3, di3, sz, ffz, fsz, fwz, zsize(1), zsize(2), zsize(3), 0, zero)
+    call derz (tc3, ti3, di3, sz, ffz, fsz, fwz, zsize(1), zsize(2), zsize(3), 0, zero)
 
     !call filz(taf3,ta3,di3,fisz,fiffzp,fifszp,fifwzp,zsize(1),zsize(2),zsize(3),1,zero)
     !call filz(tbf3,tb3,di3,fisz,fiffzp,fifszp,fifwzp,zsize(1),zsize(2),zsize(3),1,zero)

--- a/src/les_models.f90
+++ b/src/les_models.f90
@@ -106,15 +106,16 @@ contains
     USE variables
     USE decomp_2d_io
     use var, only: nut1
-    USE abl, only: wall_sgs_slip, wall_sgs_noslip
+    !USE abl, only: wall_sgs_slip, wall_sgs_noslip
     implicit none
 
-    real(mytype), dimension(xsize(1), xsize(2), xsize(3)) :: ux1, uy1, uz1, ep1
-    real(mytype), dimension(xsize(1), xsize(2), xsize(3), numscalar) :: phi1
-    real(mytype), dimension(xsize(1), xsize(2), xsize(3)) :: sgsx1, sgsy1, sgsz1
-    real(mytype), dimension(xsize(1), xsize(2), xsize(3)) :: wallfluxx1, wallfluxy1, wallfluxz1
-    real(mytype), dimension(xsize(1), xsize(2), xsize(3)) :: wallsgsx1, wallsgsy1, wallsgsz1
+    real(mytype), dimension(xsize(1), xsize(2), xsize(3)), intent(in) :: ux1, uy1, uz1, ep1
+    real(mytype), dimension(xsize(1), xsize(2), xsize(3), numscalar), intent(in) :: phi1
+    real(mytype), dimension(xsize(1), xsize(2), xsize(3)), intent(out) :: sgsx1, sgsy1, sgsz1
+    !real(mytype), dimension(xsize(1), xsize(2), xsize(3)) :: w_fluxx1, w_fluxy1, w_fluxz1
+    !real(mytype), dimension(xsize(1), xsize(2), xsize(3)) :: w_sgsx1, w_sgsy1, w_gsz1
 
+    write(*,*) "START Compute_SGS"
     ! Calculate eddy-viscosity
     if(jles.eq.1) then ! Smagorinsky
        call smag(nut1,ux1,uy1,uz1)
@@ -127,34 +128,38 @@ contains
 
     endif
 
-    if(iconserv.eq.0) then ! Non-conservative form for calculating the divergence of the SGS stresses
-       call sgs_mom_nonconservative(sgsx1,sgsy1,sgsz1,ux1,uy1,uz1,nut1,ep1)
+    !if(iconserv.eq.0) then ! Non-conservative form for calculating the divergence of the SGS stresses
+    !   call sgs_mom_nonconservative(sgsx1,sgsy1,sgsz1,ux1,uy1,uz1,nut1,ep1)
 
-       ! SGS correction for ABL
-       if(itype.eq.itype_abl) then
-          ! No-slip wall
-          if (ncly1==2) then 
-             call wall_sgs_noslip(ux1,uy1,uz1,nut1,wallfluxx1,wallfluxy1,wallfluxz1)
-             if(xstart(2)==1) then
-               sgsx1(:,2,:) = -wallfluxx1(:,2,:)
-               sgsy1(:,2,:) = -wallfluxy1(:,2,:)
-               sgsz1(:,2,:) = -wallfluxz1(:,2,:)
-             endif
-          ! Slip wall
-          elseif (ncly1==1) then
-             call wall_sgs_slip(ux1,uy1,uz1,phi1,nut1,wallfluxx1,wallfluxy1,wallfluxz1)
-             if(xstart(2)==1) then
-                sgsx1(:,1,:) = wallfluxx1(:,1,:)
-                sgsy1(:,1,:) = wallfluxy1(:,1,:)
-                sgsz1(:,1,:) = wallfluxz1(:,1,:)
-             endif
-          endif
-       endif
+    !   ! SGS correction for ABL
+    !   if(itype.eq.itype_abl) then
+    !      ! No-slip wall
+    !      if (ncly1==2) then 
+    !         call wall_sgs_noslip(ux1,uy1,uz1,nut1,wallfluxx1,wallfluxy1,wallfluxz1)
+    !         if(xstart(2)==1) then
+    !           sgsx1(:,2,:) = -wallfluxx1(:,2,:)
+    !           sgsy1(:,2,:) = -wallfluxy1(:,2,:)
+    !           sgsz1(:,2,:) = -wallfluxz1(:,2,:)
+    !         endif
+    !      ! Slip wall
+    !      elseif (ncly1==1) then
+    !         call wall_sgs_slip(ux1,uy1,uz1,phi1,nut1,wallfluxx1,wallfluxy1,wallfluxz1)
+    !         if(xstart(2)==1) then
+    !            sgsx1(:,1,:) = wallfluxx1(:,1,:)
+    !            sgsy1(:,1,:) = wallfluxy1(:,1,:)
+    !            sgsz1(:,1,:) = wallfluxz1(:,1,:)
+    !         endif
+    !      endif
+    !   endif
 
-    elseif (iconserv.eq.1) then ! Conservative form for calculating the divergence of the SGS stresses (used with wall functions)
-       call sgs_mom_conservative(sgsx1,sgsy1,sgsz1,ux1,uy1,uz1,nut1)
+    !elseif (iconserv.eq.1) then ! Conservative form for calculating the divergence of the SGS stresses (used with wall functions)
+    !   call sgs_mom_conservative(sgsx1,sgsy1,sgsz1,ux1,uy1,uz1,nut1)
 
-    endif
+    !endif
+    sgsx1 = zero
+    sgsy1 = zero
+    sgsz1 = zero
+    write(*,*) "END Compute_SGS"
 
     return
 

--- a/src/module_param.f90
+++ b/src/module_param.f90
@@ -529,6 +529,7 @@ module complex_geometry
   integer     ,allocatable,dimension(:,:)   :: nobjx,nobjy,nobjz
   integer     ,allocatable,dimension(:,:,:) :: nxipif,nxfpif,nyipif,nyfpif,nzipif,nzfpif
   real(mytype),allocatable,dimension(:,:,:) :: xi,xf,yi,yf,zi,zf
+  real(mytype),allocatable,dimension(:,:,:) :: xepsi, yepsi, zepsi  
   integer :: nxraf,nyraf,nzraf,nraf,nobjmax
 end module complex_geometry
 !############################################################################

--- a/src/navier.f90
+++ b/src/navier.f90
@@ -73,7 +73,7 @@ contains
        CALL momentum_to_velocity(rho1, ux1, uy1, uz1)
     ENDIF
 
-    CALL divergence(pp3(:,:,:,1),rho1,ux1,uy1,uz1,ep1,drho1,divu3,nlock)
+    call divergence(pp3(:,:,:,1),rho1,ux1,uy1,uz1,ep1,drho1,divu3,nlock)
     IF (ilmn.AND.ivarcoeff) THEN
        dv3(:,:,:) = pp3(:,:,:,1)
     ENDIF
@@ -275,11 +275,11 @@ contains
     real(mytype),dimension(xsize(1),xsize(2),xsize(3),nrhotime),intent(in) :: rho1
     !Z PENCILS NXM NYM NZ  -->NXM NYM NZM
     real(mytype),dimension(zsize(1),zsize(2),zsize(3)),intent(in) :: divu3
-    real(mytype),dimension(ph1%zst(1):ph1%zen(1),ph1%zst(2):ph1%zen(2),nzmsize) :: pp3
+    real(mytype),dimension(ph1%zst(1):ph1%zen(1),ph1%zst(2):ph1%zen(2),nzmsize),intent(out) :: pp3
 
     integer :: nvect3,i,j,k,nlock
     integer :: code
-    real(mytype) :: tmax,tmoy,tmax1,tmoy1
+    real(mytype) :: tmax,tmoy,tmax1,tmoy1, pres_ref
 
     nvect3=(ph1%zen(1)-ph1%zst(1)+1)*(ph1%zen(2)-ph1%zst(2)+1)*nzmsize
 
@@ -340,7 +340,11 @@ contains
     pp3(:,:,:) = pp3(:,:,:) + po3(:,:,:)
 
     if (nlock==2) then
-       pp3(:,:,:)=pp3(:,:,:)-pp3(ph1%zst(1),ph1%zst(2),nzmsize)
+       ! Line below sometimes generates issues with Intel 
+       !pp3(:,:,:)=pp3(:,:,:)-pp3(ph1%zst(1),ph1%zst(2),nzmsize)
+       ! Using a tmp variable seems to sort the issue
+       pres_ref = pp3(ph1%zst(1),ph1%zst(2),nzmsize)
+       pp3(:,:,:)=pp3(:,:,:)-pres_ref
     endif
 
     tmax=-1609._mytype
@@ -1185,7 +1189,7 @@ contains
     tc1(:,:,:) = (one - rho0 / rho1(:,:,:,1)) * pz1(:,:,:)
 
     nlock = -1 !! Don't do any funny business with LMN
-    CALL divergence(pp3,rho1,ta1,tb1,tc1,ep1,drho1,divu3,nlock)
+    call divergence(pp3,rho1,ta1,tb1,tc1,ep1,drho1,divu3,nlock)
 
     !! lapl(p) = div((1 - rho0/rho) grad(p)) + rho0(div(u*) - div(u))
     !! dv3 contains div(u*) - div(u)

--- a/src/parameters.f90
+++ b/src/parameters.f90
@@ -641,6 +641,9 @@ subroutine parameter_defaults()
   !! IBM stuff
   nraf = 0
   nobjmax = 0
+  ubcx = zero
+  ubcy = zero
+  ubcz = zero
 
   nvol = 0
   iforces = 0

--- a/src/statistics.f90
+++ b/src/statistics.f90
@@ -416,6 +416,7 @@ contains
   subroutine update_variance_vector(uum, vvm, wwm, uvm, uwm, vwm, ux, uy, uz, ep)
 
     use decomp_2d, only : xsize, xstS, xenS
+    use var, only: ta1
 
     implicit none
 
@@ -423,12 +424,23 @@ contains
     real(mytype), dimension(xstS(1):xenS(1),xstS(2):xenS(2),xstS(3):xenS(3)), intent(inout) :: uum, vvm, wwm, uvm, uwm, vwm
     real(mytype), dimension(xsize(1),xsize(2),xsize(3)), intent(in) :: ux, uy, uz, ep
 
-    call update_average_scalar(uum, ux*ux, ep)
-    call update_average_scalar(vvm, uy*uy, ep)
-    call update_average_scalar(wwm, uz*uz, ep)
-    call update_average_scalar(uvm, ux*uy, ep)
-    call update_average_scalar(uwm, ux*uz, ep)
-    call update_average_scalar(vwm, uy*uz, ep)
+    ta1(:,:,:) = ux(:,:,:)*ux(:,:,:) 
+    call update_average_scalar(uum, ta1, ep)
+    
+    ta1(:,:,:) = uy(:,:,:)*uy(:,:,:) 
+    call update_average_scalar(vvm, ta1, ep)
+    
+    ta1(:,:,:) = uz(:,:,:)*uz(:,:,:) 
+    call update_average_scalar(wwm, ta1, ep)
+    
+    ta1(:,:,:) = ux(:,:,:)*uy(:,:,:) 
+    call update_average_scalar(uvm, ta1, ep)
+    
+    ta1(:,:,:) = ux(:,:,:)*uz(:,:,:) 
+    call update_average_scalar(uwm, ta1, ep)
+    
+    ta1(:,:,:) = uy(:,:,:)*uz(:,:,:) 
+    call update_average_scalar(vwm, ta1, ep)
 
   end subroutine update_variance_vector
 

--- a/src/tools.f90
+++ b/src/tools.f90
@@ -590,16 +590,17 @@ contains
   subroutine apply_spatial_filter(ux1,uy1,uz1,phi1)
 
     use param
-    use var, only: uxf1,uyf1,uzf1,uxf2,uyf2,uzf2,uxf3,uyf3,uzf3,di1,di2,di3,phif1,phif2,phif3
+    !use var, only: uxf1,uyf1,uzf1,uxf2,uyf2,uzf2,uxf3,uyf3,uzf3,di1,di2,di3,phif1,phif2,phif3
+    use var, only: uxf1,uyf1,uzf1,di1,phif1
+    use var, only: ux2,uy2,uz2, phi2,uxf2,uyf2,uzf2,di2,phif2
+    use var, only: ux3,uy3,uz3, phi3,uxf3,uyf3,uzf3,di3,phif3
     use variables
     use ibm_param, only : ubcx,ubcy,ubcz
 
     implicit none
     real(mytype),dimension(xsize(1),xsize(2),xsize(3)), intent(inout) :: ux1,uy1,uz1
-    real(mytype),dimension(xsize(1),xsize(2),xsize(3), numscalar), intent(inout) :: phi1
+    real(mytype),dimension(xsize(1),xsize(2),xsize(3), numscalar), intent(in) :: phi1
     real(mytype),dimension(xsize(1),xsize(2),xsize(3)) :: phi11
-    real(mytype),dimension(ysize(1),ysize(2),ysize(3)) :: ux2,uy2,uz2, phi2
-    real(mytype),dimension(zsize(1),zsize(2),zsize(3)) :: ux3,uy3,uz3, phi3
 
     integer :: i,j,k,npaire
 

--- a/src/variables.f90
+++ b/src/variables.f90
@@ -85,6 +85,8 @@ contains
 
   subroutine init_variables
 
+    implicit none 
+
     TYPE(DECOMP_INFO), save :: ph! decomposition object
 
     integer :: i, j, k
@@ -628,6 +630,13 @@ contains
        zi=zero
        allocate(zf(nobjmax,zsize(1),zsize(2)))
        zf=zero
+       allocate(xepsi(nxraf,xsize(2),xsize(3))) 
+       xepsi=zero
+       allocate(yepsi(ysize(1),nyraf,ysize(3)))
+       yepsi=zero
+       allocate(zepsi(zsize(1),zsize(2),nzraf)) 
+       zepsi=zero
+
     endif
 
     !module filter

--- a/src/variables.f90
+++ b/src/variables.f90
@@ -53,6 +53,7 @@ module var
   integer, save :: nxmsize, nymsize, nzmsize
 
   ! working arrays for LES
+  ! These are by far too many variables and we should be able to decrease them
   real(mytype), save, allocatable, dimension(:,:,:) :: sgsx1,sgsy1,sgsz1,nut1,sxx1,syy1,szz1,sxy1,sxz1,syz1
   real(mytype), save, allocatable, dimension(:,:,:) :: sgsx2,sgsy2,sgsz2,nut2,sxx2,syy2,szz2,sxy2,sxz2,syz2
   real(mytype), save, allocatable, dimension(:,:,:) :: sgsx3,sgsy3,sgsz3,nut3,sxx3,syy3,szz3,sxy3,sxz3,syz3
@@ -69,9 +70,12 @@ module var
   real(mytype), save, allocatable, dimension(:,:,:) :: srt_smag, srt_smag2
   real(mytype), save, allocatable, dimension(:,:,:) :: srt_wale, srt_wale2, srt_wale3, srt_wale4
 
+
   ! working arrays for ABL
   real(mytype), save, allocatable, dimension(:,:) :: heatflux
   real(mytype), save, allocatable, dimension(:,:,:,:) :: abl_T
+  ! tmp fix for intel
+  real(mytype), save, allocatable, dimension(:,:,:) :: wallfluxx1, wallfluxy1, wallfluxz1  
 
   ! arrays for turbine modelling
   real(mytype), save, allocatable, dimension(:,:,:) :: FTx, FTy, FTz, Fdiscx, Fdiscy, Fdiscz
@@ -474,6 +478,12 @@ contains
        srt_smag=zero
        call alloc_x(srt_wale)
        srt_wale=zero
+       call alloc_x(wallfluxx1)
+       wallfluxx1=zero
+       call alloc_x(wallfluxy1)
+       wallfluxy1=zero
+       call alloc_x(wallfluxz1)
+       wallfluxz1=zero
        call alloc_y(sgsx2)
        sgsx2=zero
        call alloc_y(sgsy2)

--- a/src/visu.f90
+++ b/src/visu.f90
@@ -485,6 +485,7 @@ contains
     use var, only : ep1
     use var, only : zero, one
     use var, only : uvisu
+    use var, only : ta1
     use param, only : iibm
     use decomp_2d_io, only : decomp_2d_write_one, decomp_2d_write_plane
 
@@ -495,7 +496,7 @@ contains
     integer, intent(in) :: num
     logical, optional, intent(in) :: skip_ibm, flush
 
-    real(mytype), dimension(xsize(1),xsize(2),xsize(3)) :: local_array
+    !real(mytype), dimension(xsize(1),xsize(2),xsize(3)) :: local_array
     logical :: mpiio, force_flush
     
     integer :: ierr
@@ -558,23 +559,23 @@ contains
     endif
 
     if ((iibm == 2) .and. .not.present(skip_ibm)) then
-       local_array(:,:,:) = (one - ep1(:,:,:)) * f1(:,:,:)
+       ta1(:,:,:) = (one - ep1(:,:,:)) * f1(:,:,:)
     else
-       local_array(:,:,:) = f1(:,:,:)
+       ta1(:,:,:) = f1(:,:,:)
     endif
     if (output2D.eq.0) then
        if (mpiio .or. (iibm == 2) .or. force_flush) then
           !! XXX: This (re)uses a temporary array for data - need to force synchronous writes.
           uvisu = zero
           
-          call fine_to_coarseV(1,local_array,uvisu)
+          call fine_to_coarseV(1,ta1,uvisu)
           call decomp_2d_write_one(1,uvisu,"data",gen_filename(pathname, filename, num, 'bin'),2,io_name,&
                opt_deferred_writes=.false.)
        else
           call decomp_2d_write_one(1,f1,"data",gen_filename(pathname, filename, num, 'bin'),0,io_name)
        end if
     else
-       call decomp_2d_write_plane(1,local_array,output2D,-1,"data",gen_filename(pathname, filename, num, 'bin'),io_name)
+       call decomp_2d_write_plane(1,ta1,output2D,-1,"data",gen_filename(pathname, filename, num, 'bin'),io_name)
     endif
 
   end subroutine write_field

--- a/test/data/Taylor-Green-Vortex/adios2_config.xml
+++ b/test/data/Taylor-Green-Vortex/adios2_config.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0"?>
+<adios-config>
+  <io name="solution-io">
+    <engine type="BP4">
+    </engine>
+    <transport type="File">
+      <parameter key="Library" value="fstream"/>
+      <parameter key="ProfileUnits" value="Milliseconds"/>
+    </transport>
+  </io>
+  <io name="in-outflow-io">
+    <engine type="BP4">
+    </engine>
+    <transport type="File">
+      <parameter key="Library" value="fstream"/>
+      <parameter key="ProfileUnits" value="Milliseconds"/>
+    </transport>
+  </io>
+  <io name="turb-io">
+    <engine type="BP4">
+    </engine>
+    <transport type="File">
+      <parameter key="Library" value="fstream"/>
+      <parameter key="ProfileUnits" value="Milliseconds"/>
+    </transport>
+  </io>
+  <io name="restart-io">
+    <engine type="BP4">
+    </engine>
+    <transport type="File">
+      <parameter key="Library" value="fstream"/>
+      <parameter key="ProfileUnits" value="Milliseconds"/>
+    </transport>
+  </io>
+  <io name="statistics-io">
+    <engine type="BP4">
+    </engine>
+    <transport type="File">
+      <parameter key="Library" value="fstream"/>
+      <parameter key="ProfileUnits" value="Milliseconds"/>
+    </transport>
+  </io>
+  <io name="restart-forces-io">
+    <engine type="BP4">
+    </engine>
+    <transport type="File">
+      <parameter key="Library" value="fstream"/>
+      <parameter key="ProfileUnits" value="Milliseconds"/>
+    </transport>
+  </io>
+</adios-config>


### PR DESCRIPTION
This PR is to resolve issues with the Intel compilers. Several segmentation faults like 
`forrtl: severe (174): SIGSEGV, segmentation fault occurred`
appears in several test mainly related to SGS modelling and IBM. 
These error were also problem size dependant, appearing only for relatively large cases. 

The vast majority of these issues were related to local definition large multidimensional arrays such as 
`real(mytype), dimension(xsize(1),xsize(2),xsize(3)) :: local_array`
within a subroutine. 

The general solution has been to use already allocated tmp appays like `ta1` instead of defining some new. In case this was not possible some new arrays have been defined in `module var`. 
 