### PR TITLE
Fixing fortran

### DIFF
--- a/src/acl_out.f90
+++ b/src/acl_out.f90
@@ -27,7 +27,7 @@ contains
       do ielem=1,act_line%NElem
           inquire (File='loads/'//trim(act_line%name)//'_element_'//trim(int2str(ielem))//'.load', exist=exists)
           if (.not. exists) then
-            call system('mkdir -p loads 2> /dev/null')
+            call execute_command_line('mkdir -p loads 2> /dev/null')
             open(2017,File='loads/'//trim(act_line%name)//'_element_'//trim(int2str(ielem))//'.load')
             write(2017,*) 'iteration,time,X,Y,Z,rdist/R,AOA,adot,RE,ur,CL,CD,CM25,Cn,Ct,Fn,Ft,F1'
             write(2017,*) '[-],[s],[m],[m],[m],[-],[deg],[deg/s],[-],[m/s],[-],[-],[-],[-],[-],[N],[N],[-]'
@@ -58,7 +58,7 @@ contains
       do ielem=1,act_line%NElem
           inquire (File='loads/'//trim(act_line%name)//'_element_'//trim(int2str(ielem))//'.dynstall', exist=exists)
           if (.not. exists) then
-              call system('mkdir -p loads 2> /dev/null')
+              call execute_command_line('mkdir -p loads 2> /dev/null')
               open(2018,File='loads/'//trim(act_line%name)//'_element_'//trim(int2str(ielem))//'.dynstall')
               write(2018,*) 'iteration,time,rdist/R,pitch,AOA,f'
               close(2018)

--- a/src/forces.f90
+++ b/src/forces.f90
@@ -908,7 +908,7 @@ contains
          
          if (nrank .eq. 0) then
              write(38,*) t,xDrag_mean,yLift_mean 
-             call flush(38)
+             flush(38)
          endif
        enddo
     endif

--- a/src/ibm.f90
+++ b/src/ibm.f90
@@ -524,24 +524,24 @@ subroutine cubsplx(u,lind)
                   u(ipol,j,k)=bcimp                                   
               else
               ! Cubic Spline Reconstruction
-		  na=ia
-		  do ipol=ipoli,ipolf
-		     if ((inxf.eq.1).and.(inxi.eq.1)) then ! If the Body Extends from the Inlet to the Outlet (Special Case)
-                 u(ipol,j,k)=bcimp                            
-             else
-		         xpol=dx*(ipol-1)
-		         if (xpol.eq.ana_resi) then
-		            u(ipol,j,k)=bcimp
-		         elseif (xpol.eq.ana_resf) then
-		            u(ipol,j,k)=bcimp
-		         else   
-		            call cubic_spline(xa,ya,na,xpol,ypol)
-		            u(ipol,j,k)=ypol
-		         endif
-		     endif
-		  enddo
-		  ia=0
-	      endif    
+                 na=ia
+                 do ipol=ipoli,ipolf
+                    if ((inxf.eq.1).and.(inxi.eq.1)) then ! If the Body Extends from the Inlet to the Outlet (Special Case)
+                       u(ipol,j,k)=bcimp                            
+                    else
+                       xpol=dx*(ipol-1)
+                       if (xpol.eq.ana_resi) then
+                          u(ipol,j,k)=bcimp
+                       elseif (xpol.eq.ana_resf) then
+                          u(ipol,j,k)=bcimp
+                       else   
+                          call cubic_spline(xa,ya,na,xpol,ypol)
+                          u(ipol,j,k)=ypol
+                       endif
+                    endif
+                 enddo
+                 ia=0
+              endif
            enddo
         endif
      enddo
@@ -690,21 +690,21 @@ subroutine cubsply(u,lind)
               if (yi(j,i,k).eq.yf(j,i,k)) then
                   u(i,jpol,k)=bcimp                                   
               else
-		  !calcul du polynôme
-		   na=ia
-		   do jpol=jpoli,jpolf
-		         xpol=yp(jpol)
-		         if (xpol.eq.ana_resi) then
-		            u(i,jpol,k)=bcimp
-		         elseif (xpol.eq.ana_resf) then
-		            u(i,jpol,k)=bcimp
-		         else   
-		            call cubic_spline(xa,ya,na,xpol,ypol)
-		            u(i,jpol,k)=ypol
-		         endif
-		   enddo
-		   ia=0
-	      endif    
+                 !calcul du polynôme
+                 na=ia
+                 do jpol=jpoli,jpolf
+                    xpol=yp(jpol)
+                    if (xpol.eq.ana_resi) then
+                       u(i,jpol,k)=bcimp
+                    elseif (xpol.eq.ana_resf) then
+                       u(i,jpol,k)=bcimp
+                    else   
+                       call cubic_spline(xa,ya,na,xpol,ypol)
+                       u(i,jpol,k)=ypol
+                    endif
+                 enddo
+                 ia=0
+              endif
            enddo
         endif
      enddo
@@ -837,28 +837,28 @@ subroutine cubsplz(u,lind)
                     endif
                  enddo
               endif
-         !     ! Special Case
-         !     if (zi(k,i,j).eq.zf(k,i,j)) then
-         !         u(i,j,kpol)=bcimp                                   
-         !     else              
-    	      ! Cubic Spline Reconstruction
-	            na=ia
-	            do kpol=kpoli,kpolf 
-                          ! Special Case
-                          if (zi(k,i,j).eq.zf(k,i,j)) then
-                                u(i,j,kpol)=bcimp
-                          else
-	                    if ((inxf.eq.1).and.(inxi.eq.1)) then ! If the Body Extends from the Front to the Back (Special Case)
-	                          u(i,j,kpol)=bcimp                            
-	                     else              
-	                          xpol=dz*(kpol-1)
-	                          call cubic_spline(xa,ya,na,xpol,ypol)
-	                          u(i,j,kpol)=ypol
-	                     endif
-                           endif
-	            enddo
-	            ia=0
-         !     endif
+              !     ! Special Case
+              !     if (zi(k,i,j).eq.zf(k,i,j)) then
+              !         u(i,j,kpol)=bcimp                                   
+              !     else              
+              ! Cubic Spline Reconstruction
+              na=ia
+              do kpol=kpoli,kpolf 
+                 ! Special Case
+                 if (zi(k,i,j).eq.zf(k,i,j)) then
+                    u(i,j,kpol)=bcimp
+                 else
+                    if ((inxf.eq.1).and.(inxi.eq.1)) then ! If the Body Extends from the Front to the Back (Special Case)
+                       u(i,j,kpol)=bcimp                            
+                    else              
+                       xpol=dz*(kpol-1)
+                       call cubic_spline(xa,ya,na,xpol,ypol)
+                       u(i,j,kpol)=ypol
+                    endif
+                 endif
+              enddo
+              ia=0
+              !     endif
            enddo
         endif
      enddo


### PR DESCRIPTION
Addresses some minor code issues that weren't compiling under gfortran due to standards compliance:
`call system` -> `call execute_command_line`
`call flush` -> `flush`
replace tabs with spaces