### PR TITLE
Use DEBG only for dev builds

### DIFF
--- a/cmake/X3D_Compilers.cmake
+++ b/cmake/X3D_Compilers.cmake
@@ -8,11 +8,11 @@ message(STATUS "Fortran compiler version ${CMAKE_Fortran_COMPILER_VERSION}")
 
 set(CMAKE_Fortran_PREPROCESS ON)
 if (CMAKE_BUILD_TYPE MATCHES "DEBUG")
-  add_definitions("-DDEBUG -DDEBG")
+  add_definitions("-DDEBUG")
 endif (CMAKE_BUILD_TYPE MATCHES "DEBUG")
 
 if (CMAKE_BUILD_TYPE MATCHES "DEV")
-  message(FATAL_ERROR "The code is not ready for DEV builds")
+  add_definitions("-DDEBUG -DDEBG")
 endif (CMAKE_BUILD_TYPE MATCHES "DEV")
 
 if (ENABLE_INPLACE)


### PR DESCRIPTION
In case of debug builds, a lot of things are printed currently. With the modification, debug builds will print less things.